### PR TITLE
Improve JdbcExecutor traversal by safely handling missing or multiple consumers

### DIFF
--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
@@ -371,14 +371,29 @@ public class JdbcExecutor extends ExecutorTemplate {
 
         final Channel outputChannel = task.getOutputChannel(0);
 
-        if (outputChannel.getConsumers().size() != 1) {
+        final Collection<ExecutionTask> consumers = outputChannel.getConsumers();
+
+        // No consumer → end of pipeline
+        if (consumers.isEmpty()) {
             return null;
         }
 
-        final ExecutionTask consumer = outputChannel.getConsumers().iterator().next();
+        // Multiple consumers are currently unsupported
+        if (consumers.size() != 1) {
+            throw new WayangException(
+                String.format("Expected a single consumer for task %s but found %d.",
+                task,
+                consumers.size()
+                )
+            );
+    }
 
-        return consumer.getStage() == stage && consumer.getOperator() instanceof JdbcExecutionOperator ? consumer
-                        : null;
+    final ExecutionTask consumer = consumers.iterator().next();
+
+    return consumer.getStage() == stage
+         && consumer.getOperator() instanceof JdbcExecutionOperator
+         ? consumer
+         : null;
     }
 
     private static SqlQueryChannel.Instance instantiateOutboundChannel(final ExecutionTask task,

--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/execution/JdbcExecutorTest.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/execution/JdbcExecutorTest.java
@@ -21,6 +21,7 @@ package org.apache.wayang.jdbc.execution;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.api.Job;
+import org.apache.wayang.core.api.exception.WayangException;
 import org.apache.wayang.core.function.PredicateDescriptor;
 import org.apache.wayang.core.optimizer.DefaultOptimizationContext;
 import org.apache.wayang.core.plan.executionplan.ExecutionStage;
@@ -42,6 +43,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,6 +85,48 @@ class JdbcExecutorTest {
         assertEquals(
                 "SELECT * FROM customer;",
                 sqlQueryChannelInstance.getSqlQuery()
+        );
+    }
+
+    @Test
+    void testExecuteWithMultipleConsumers() throws SQLException {
+        Configuration configuration = new Configuration();
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        when(job.getCrossPlatformExecutor())
+            .thenReturn(new CrossPlatformExecutor(job, new NoInstrumentationStrategy()));
+
+        SqlQueryChannel.Descriptor sqlChannelDescriptor =
+            HsqldbPlatform.getInstance().getSqlQueryChannelDescriptor();
+
+        ExecutionStage sqlStage = mock(ExecutionStage.class);
+
+        JdbcTableSource tableSource = new HsqldbTableSource("customer");
+        ExecutionTask tableSourceTask = new ExecutionTask(tableSource);
+
+        SqlQueryChannel outputChannel =
+            new SqlQueryChannel(sqlChannelDescriptor, tableSource.getOutput(0));
+        tableSourceTask.setOutputChannel(0, outputChannel);
+        tableSourceTask.setStage(sqlStage);
+
+        when(sqlStage.getStartTasks()).thenReturn(Collections.singleton(tableSourceTask));
+        when(sqlStage.getTerminalTasks()).thenReturn(Collections.singleton(tableSourceTask));
+
+        ExecutionTask firstConsumer = mock(ExecutionTask.class);
+        ExecutionTask secondConsumer = mock(ExecutionTask.class);
+
+        outputChannel.getConsumers().add(firstConsumer);
+        outputChannel.getConsumers().add(secondConsumer);
+
+        JdbcExecutor executor = new JdbcExecutor(HsqldbPlatform.getInstance(), job);
+
+        assertThrows(
+            WayangException.class,
+            () -> executor.execute(
+                    sqlStage,
+                    new DefaultOptimizationContext(job),
+                    job.getCrossPlatformExecutor()
+            )
         );
     }
 


### PR DESCRIPTION
This PR makes the JdbcExecutor more robust by ensuring that it handles situations where there are either zero consumers or multiple consumers of the execution task gracefully.

Change:

Returns null if the output channel has zero consumers rather than assuming that there is exactly one consumer.
Throws a helpful WayangException if there are multiple consumers of the execution task rather than making any unchecked assumptions.
Keeps the existing behavior intact for the typical case of having exactly one consumer.

This PR replaces my earlier PR for the same change. The branch has been recreated from the latest main after upstream refactoring made rebasing the previous branch impractical.