### PR TITLE
Docker development environment for Glasgow hackathon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,36 +1,15 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+.git
+.gitignore
 
-*
-!Dockerfile
-!python/
-python/**
-!python/Dockerfile
-!python/docker/
-!python/docker/**
-!python/examples/
-!python/examples/**
-!python/pyproject.toml
-!python/setup.cfg
-!python/README.md
-!python/src/
-python/src/**
-!python/src/pywy/
-!python/src/pywy/**
-!wayang-assembly/
-wayang-assembly/**
-!wayang-assembly/target/
-wayang-assembly/target/**
-!wayang-assembly/target/*-dist.tar.gz
+**/target/
+
+.idea/
+.vscode/
+*.iml
+
+*.log
+
+.DS_Store
+Thumbs.db
+
+.m2/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,33 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jre AS wayang-assembler
+FROM eclipse-temurin:17-jdk
 
-ARG WAYANG_DIST=wayang-assembly/target/*-dist.tar.gz
+WORKDIR /workspace/wayang
 
-COPY ${WAYANG_DIST} /tmp/wayang-dist.tar.gz
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git bash \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/wayang-root /opt/wayang /opt/wayang/smoke \
-    && tar -xzf /tmp/wayang-dist.tar.gz -C /opt/wayang-root \
-    && extracted_dir="$(find /opt/wayang-root -mindepth 1 -maxdepth 1 -type d -name 'wayang-*' | head -n 1)" \
-    && test -n "${extracted_dir}" \
-    && cp -a "${extracted_dir}/." /opt/wayang/ \
-    && find /opt/wayang -type f \( -name "*-sources.jar" -o -name "*-javadoc.jar" -o -name "README.md" \) -delete \
-    && printf "apache wayang docker smoke test\n" > /opt/wayang/smoke/wordcount.txt \
-    && rm /tmp/wayang-dist.tar.gz
+COPY . /workspace/wayang
 
-FROM eclipse-temurin:17-jre
+RUN sed -i 's/\r$//' mvnw \
+    && chmod +x mvnw
 
-ENV WAYANG_HOME=/opt/wayang
-ENV FLAG_WAYANG=true
-ENV PATH="${WAYANG_HOME}/bin:${PATH}"
+COPY docker/entrypoint.sh /usr/local/bin/wayang-entrypoint
 
-COPY --from=wayang-assembler /opt/wayang /opt/wayang
+RUN chmod +x /usr/local/bin/wayang-entrypoint
 
-RUN mkdir -p /root/.wayang /opt/wayang/conf \
-    && touch /opt/wayang/conf/wayang.properties
-
-WORKDIR /opt/wayang
-
-ENTRYPOINT ["/opt/wayang/bin/wayang-submit"]
-CMD ["org.apache.wayang.apps.pi.PiEstimation", "java", "1"]
+ENTRYPOINT ["wayang-entrypoint"]
+CMD ["bash"]

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -1,0 +1,20 @@
+# Wayang Hackathon Development Environment
+
+This guide provides a Docker-based development environment for the Wayang
+hackathon.
+
+The goal is to allow participants to get a working Wayang environment without
+having to install Java, Maven, Spark, Hadoop, or other Wayang dependencies
+locally.
+
+## Prerequisites
+
+Install:
+
+- Git
+- Docker Desktop
+
+Verify Docker is available:
+
+```bash
+docker --version

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  wayang:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: wayang-hackathon
+    working_dir: /workspace/wayang
+    volumes:
+      - .:/workspace/wayang
+      - wayang-maven-cache:/root/.m2
+    stdin_open: true
+    tty: true
+
+volumes:
+  wayang-maven-cache:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -f /workspace/wayang/mvnw ]; then
+    sed -i 's/\r$//' /workspace/wayang/mvnw
+    chmod +x /workspace/wayang/mvnw
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker-based development environment for the Wayang hackathon.
Environment provides Java 17 and Maven through a container, mounts the wayang source tree for development, persists the Maven dependency cache, and handles windows CRLF line endings for the Maven wrapper.
I've tested the environment by successfully building wayang-commons, wayang-platforms and wayang-assembly distribution.
Participants only need git and docker desktop installed locally