### PR TITLE
[WAYANG-613] Improve documentation structure, abstractions, and deep learning guide

### DIFF
--- a/wayang-docs/src/main/resources/_config.prod.yml
+++ b/wayang-docs/src/main/resources/_config.prod.yml
@@ -17,7 +17,7 @@
 
 url: "https://wayang.apache.org"
 baseurl: ""
-title: "Apache Wayang (incubating) - Documentation"
+title: "Apache Wayang - Documentation"
 permalink: pretty
 collections:
   publications:

--- a/wayang-docs/src/main/resources/_config.yml
+++ b/wayang-docs/src/main/resources/_config.yml
@@ -17,7 +17,7 @@
 
 url: "http://127.0.0.1:4000"
 baseurl: ""
-title: "Apache Wayang (incubating) - Documentation"
+title: "Apache Wayang - Documentation"
 permalink: pretty
 collections:
   publications:

--- a/wayang-docs/src/main/resources/_data/menus.yml
+++ b/wayang-docs/src/main/resources/_data/menus.yml
@@ -13,97 +13,104 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 header:
-#  - url: /what_is_wayang/
-#    title: What is Wayang?
-#    identifier: what_wayang
-#    weight: 1
+  - url: /what_is_wayang/
+    title: What is Wayang?
+    identifier: what_wayang
+    weight: 1
 
-#  - url: /getting_start/
-#    title: Getting Started with Wayang
-#    identifier: getting_start
-#    weight: 2
+  - url: /getting_start/
+    title: Getting Started
+    identifier: getting_start
+    weight: 2
 
-#  - url: /using_wayang/
-#    title: Using Wayang
-#    identifier: using
-#    weight: 3
-
-#  - url: /extending_wayang/
-#    title: Extending Wayang
-#    identifier: extending
-#    weight: 4
+  - url: /using_wayang/
+    title: Using Wayang
+    identifier: using
+    weight: 3
 
   - url: /how_contribute/
     title: How To Contribute
     identifier: contribute
+    weight: 4
+
+  - url: https://wayang.apache.org/docs/api/javadocs/
+    title: API JavaDocs
+    identifier: javadoc
     weight: 5
 
+getting_start:
+  - url: /getting_start/how_build/
+    title: How To Build Wayang
+    identifier: build
+    weight: 0
 
-#getting_start:
-#  - url: /getting_start/how_build/
-#    title: How To Build Wayang
-#    identifier: build
-#    weight: 0
-#
-#  - url: /getting_start/how_install/
-#    title: How To Install Wayang
-#    identifier: install
-#    weight: 1
-#
-#  - url: /getting_start/how_run/
-#    title: How To Run Wayang
-#    identifier: run
-#    weight: 2
-#
-#  - url: /getting_start/writting_wayang_plan/
-#    title: Writting a Wayang Plan
-#    identifier: writting
-#    weight: 3
+  - url: /getting_start/how_install/
+    title: How To Install Wayang
+    identifier: install
+    weight: 1
 
-#using:
-#  - url: /using_wayang/api_java_scala/
-#    title: API Java/Scala
-#    identifier: api_java
-#    weight: 0
-#
-#  - url: /using_wayang/api_python/
-#    title: API Python
-#    identifier: api_python
-#    weight: 1
-#
-#  - url: /using_wayang/api_rest/
-#    title: API REST
-#    identifier: api_rest
-#    weight: 2
+  - url: /getting_start/how_run/
+    title: How To Run Wayang
+    identifier: run
+    weight: 2
 
-#  - url: /using_wayang/api_sql/
-#    title: API SQL
-#    identifier: api_sql
-#    weight: 3
-#
-#  - url: /using_wayang/api_jdbc/
-#    title: API JDBC
-#    identifier: api_jdbc
-#    weight: 4
+  - url: /getting_start/writting_wayang_plan/
+    title: Wayang Abstractions & Plans
+    identifier: writting
+    weight: 3
 
-#extending:
-#  - url: /extending_wayang/adding_platform/
-#    title: Adding Platform
-#    identifier: platform
-#    weight: 0
+using:
+  - url: /using_wayang/api_java_scala/
+    title: API Java/Scala
+    identifier: api_java
+    weight: 0
+
+  - url: /using_wayang/api_python/
+    title: API Python
+    identifier: api_python
+    weight: 1
+
+  - url: /using_wayang/api_rest/
+    title: API REST
+    identifier: api_rest
+    weight: 2
+
+  - url: /using_wayang/api_sql/
+    title: API SQL
+    identifier: api_sql
+    weight: 3
+
+  - url: /using_wayang/api_jdbc/
+    title: API JDBC
+    identifier: api_jdbc
+    weight: 4
+
+  - url: /using_wayang/configuring_wayang/
+    title: Configuring Wayang
+    identifier: configuring
+    weight: 5
+
+  - url: /using_wayang/cost_model_calibration/
+    title: Cost Model Calibration
+    identifier: cost_model
+    weight: 6
+
+  - url: /using_wayang/scalable_deep_learning/
+    title: Scalable Deep Learning
+    identifier: deep_learning
+    weight: 7
 
 contribute:
   - url: /how_contribute/code_changes/
     title: Code Changes
     identifier: code_changes
-    weight: 4
-
+    weight: 1
 
 code_changes:
   - url: /how_contribute/code_changes/preparing_contribute_code_changes/
     title: Preparing to Contribute Code Changes
     identifier: preparing_code_changes
-    weight: 5
+    weight: 1
 
 
 

--- a/wayang-docs/src/main/resources/getting_start/how_build/build_step.md
+++ b/wayang-docs/src/main/resources/getting_start/how_build/build_step.md
@@ -8,7 +8,7 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,14 +17,69 @@ license: |
 layout: default
 title: "Step by Step Building Wayang"
 previous:
-    url: /
-    title: previous
+    url: /getting_start/how_build/
+    title: How to Build Wayang
 next:
-    url: /
-    title: next
-menus:
+    url: /getting_start/how_install/
+    title: How to Install Wayang
+menu:
     build:
         weight: 1
 ---
 
-Step by Step Building Wayang
+# Step by Step Building Wayang
+
+Follow these step-by-step instructions to compile, test, and package Apache Wayang on your machine.
+
+---
+
+### Step 1: Clone the Git Repository
+```shell
+$ git clone https://github.com/apache/wayang.git
+$ cd wayang
+```
+
+---
+
+### Step 2: Verify System Prerequisites
+Ensure that your `JAVA_HOME` points to JDK 17 and that Java is in your system PATH:
+
+```shell
+$ java -version
+# Expected: openjdk version "17.0.x"
+```
+
+---
+
+### Step 3: Compile and Install Core Libraries
+Build the core framework and platform adapters using the included Maven wrapper:
+
+```shell
+$ ./mvnw clean install -DskipTests
+```
+
+This compiles all modules into your local Maven cache (`~/.m2/repository`).
+
+---
+
+### Step 4: Building Specific Modules
+You can build individual sub-modules to accelerate development workflows:
+
+```shell
+# Build only core and basic modules
+$ ./mvnw clean install -pl wayang-commons/wayang-core,wayang-commons/wayang-basic -DskipTests
+
+# Build the Spark platform adapter
+$ ./mvnw clean install -pl wayang-platforms/wayang-spark -DskipTests
+```
+
+---
+
+### Step 5: Assembling Binary Distributions
+To assemble the full redistributable binary tarball containing executable scripts and dependencies:
+
+```shell
+$ ./mvnw clean package -Pdistro -DskipTests
+```
+
+The resulting archives are generated in `wayang-assembly/target/`.

--- a/wayang-docs/src/main/resources/getting_start/how_build/index.md
+++ b/wayang-docs/src/main/resources/getting_start/how_build/index.md
@@ -8,7 +8,7 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,63 @@ license: |
 layout: default
 title: "How to Build Wayang"
 previous:
-    url: /
-    title: previous
+    url: /getting_start/
+    title: Getting Started
 next:
-    url: /
-    title: next
+    url: /getting_start/how_build/build_step/
+    title: Step by Step Building Wayang
+menu:
+    getting_start:
+        weight: 0
 ---
 
-How to Build Wayang
+# How to Build Apache Wayang
+
+This guide details the system prerequisites, environment setup, and Maven commands required to build Apache Wayang from source.
+
+---
+
+## Requirements
+
+Before building Apache Wayang from source, ensure your environment meets the following specifications:
+
+- **Java Development Kit (JDK)**: JDK 17.
+- **Scala**: Version 2.12.x.
+- **Apache Maven**: Maven 3.8.0 or newer (or use the included Maven wrapper `./mvnw` / `mvnw.cmd`).
+- **Platform Prerequisites**:
+  - **Linux / macOS**: Standard development toolchains (`tar`, `gzip`).
+  - **Windows**: Requires Hadoop winutils binaries located in `%HADOOP_HOME%\bin\winutils.exe` if running Hadoop/Spark integration locally.
+
+---
+
+## Building from Source
+
+### Quick Build (Skipping Tests)
+To build all Wayang modules and compile JARs without running test suites:
+
+```shell
+$ git clone https://github.com/apache/wayang.git
+$ cd wayang
+$ ./mvnw clean install -DskipTests
+```
+
+### Full Build with Tests
+To run unit and platform integration tests:
+
+```shell
+$ ./mvnw clean install
+```
+
+---
+
+## Build Profiles
+
+Wayang provides specialized Maven build profiles for assembling distributions and targeting execution environments:
+
+| Profile | Command | Purpose |
+|---|---|---|
+| `distro` | `./mvnw clean install -Pdistro` | Assembles the complete binary release archive in `wayang-assembly`. |
+| `standalone` | `./mvnw clean install -Pstandalone` | Packages bundled dependencies so standalone applications do not need external cluster libraries. |
+| `web-documentation` | `./mvnw site -pl wayang-docs -Pweb-documentation` | Builds the Jekyll documentation site. |
+
+For step-by-step guidance, see [Step by Step Building Wayang]({% link getting_start/how_build/build_step.md %}).

--- a/wayang-docs/src/main/resources/getting_start/index.md
+++ b/wayang-docs/src/main/resources/getting_start/index.md
@@ -8,7 +8,7 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,37 @@ layout: default
 title: "Getting Started"
 previous:
     url: /
-    title: previous
+    title: Read Me
 next:
-    url: /
-    title: next
+    url: /getting_start/how_build/
+    title: How to Build Wayang
+menu:
+    header:
+        weight: 2
 ---
 
-Getting Started with Wayang
+# Getting Started with Apache Wayang
+
+Welcome to Apache Wayang! This section guides you through the initial steps to get up and running, build the system, understand core concepts, and assemble your first cross-platform data processing application.
+
+---
+
+## Getting Started Sections
+
+1. **[How to Build Wayang]({% link getting_start/how_build/index.md %})**  
+   Prerequisites, system requirements (Java 17, Scala 2.12, Maven), and building Wayang from source using standard profiles.
+
+2. **[How to Install Wayang]({% link getting_start/how_install/index.md %})**  
+   Adding Wayang dependencies to your Maven or Gradle builds and configuring artifact repositories.
+
+3. **[How to Run Wayang]({% link getting_start/how_run/index.md %})**  
+   Running Wayang applications and executing binaries via the CLI submission tools.
+
+4. **[Wayang Abstractions & Plans]({% link getting_start/writting_wayang_plan/index.md %})**  
+   Understanding Wayang's fundamental operator abstractions (Source, Unary, Binary, Loop, Sink) and constructing pipelines using `JavaPlanBuilder`.
+
+---
+
+## API Documentation
+
+For the full reference of classes, packages, and interfaces, explore the official [Wayang API JavaDocs](https://wayang.apache.org/docs/api/javadocs/).

--- a/wayang-docs/src/main/resources/getting_start/writting_wayang_plan/index.md
+++ b/wayang-docs/src/main/resources/getting_start/writting_wayang_plan/index.md
@@ -8,20 +8,127 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
 layout: default
-title: "Writting a Wayang Plan"
+title: "Wayang Abstractions & Plans"
 previous:
-    url: /
-    title: previous
+    url: /getting_start/how_run/
+    title: How to Run Wayang
 next:
-    url: /
-    title: next
+    url: /using_wayang/
+    title: Using Wayang
+menu:
+    getting_start:
+        weight: 3
 ---
 
-Writting a Wayang Plan
+# Wayang Abstractions & Writing Plans
+
+Apache Wayang represents data processing applications as directed acyclic (or cyclic) dataflow graphs composed of platform-independent logical operators. At optimization time, Wayang translates these high-level operators into concrete execution operators mapped to the optimal underlying processing platforms (such as Java Streams, Apache Spark, Flink, or relational databases).
+
+---
+
+## Core Operator Abstractions
+
+Wayang categorizes all data transformations into five fundamental operator archetypes:
+
+### 1. Source Operators
+Source operators serve as the root entry points of a Wayang plan. They ingest raw data from external storage systems or collections without accepting input channels:
+- **`TextFileSource`**: Reads text files from local disk, HDFS, or S3 line by line.
+- **`TableSource`**: Queries structured relational database tables or views (e.g., PostgreSQL, SQLite).
+- **`CollectionSource`**: Wraps in-memory Java/Scala collections into a distributed dataflow.
+
+### 2. Unary Operators
+Unary operators process a single input dataset to produce a transformed output dataset:
+- **`MapOperator`**: Applies a transformation function to each element (1-to-1).
+- **`FilterOperator`**: Retains elements satisfying a boolean predicate.
+- **`FlatMapOperator`**: Transforms each element into zero, one, or more output elements.
+- **`ReduceByOperator`**: Aggregates elements sharing the same key.
+- **`SortOperator`**: Orders records by specific sort keys.
+- **`CountOperator`**: Calculates dataset cardinality.
+
+### 3. Binary Operators
+Binary operators accept two distinct input datasets and produce an output dataset:
+- **`JoinOperator`**: Performs relational inner or outer joins matching key extractors across two datasets.
+- **`UnionAllOperator`**: Combines two datasets of identical data types into one unified stream.
+- **`CartesianOperator`**: Computes the full cross-product of two input collections.
+- **`IntersectOperator`**: Returns the set intersection between two collections.
+
+### 4. Loop Operators
+Loop operators support iterative and recursive processing cycles, enabling complex graph and machine learning workflows:
+- **`LoopOperator` / `DoWhileOperator`**: Iteratively applies a loop body until a convergence predicate or maximum iteration count is reached (crucial for algorithms like PageRank, K-Means, and Gradient Descent).
+- **`RepeatOperator`**: Repeats a sub-plan for a fixed number of iterations.
+
+### 5. Sink Operators
+Sink operators terminate the execution plan by writing output datasets to destination sinks or returning them to the driver application:
+- **`TextFileSink`**: Serializes records to text files on local storage or distributed filesystems.
+- **`CollectionSink` / `LocalCallbackSink`**: Collects records back into JVM memory or invokes a user callback for each produced element.
+
+---
+
+## Assembling Plans with `PlanBuilder`
+
+The primary way to author Wayang applications in Java and Scala is through the fluent `PlanBuilder` API (`JavaPlanBuilder`).
+
+### Key PlanBuilder Components
+- **`WayangContext`**: Holds execution configuration and registers the available platform plugins (e.g., `Java.basicPlugin()`, `Spark.basicPlugin()`).
+- **`JavaPlanBuilder`**: Provides fluent factory methods to chain operators together.
+- **`DataQuantaBuilder`**: Represents a intermediate dataset within the plan, providing transformation methods (`map`, `filter`, `reduceByKey`, `join`).
+
+### Example: Building a WordCount Plan
+
+```java
+import org.apache.wayang.api.JavaPlanBuilder;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.WayangContext;
+import org.apache.wayang.java.Java;
+import org.apache.wayang.spark.Spark;
+import java.util.Collection;
+import java.util.Arrays;
+
+public class WordCountExample {
+
+    public static void main(String[] args) {
+        // 1. Create a Wayang context with target plugins
+        WayangContext context = new WayangContext(new Configuration())
+                .withPlugin(Java.basicPlugin())
+                .withPlugin(Spark.basicPlugin());
+
+        // 2. Initialize the fluent plan builder
+        JavaPlanBuilder planBuilder = new JavaPlanBuilder(context);
+
+        // 3. Assemble the plan: Source -> Unary -> Binary -> Sink
+        Collection<Tuple2<String, Integer>> wordCounts = planBuilder
+                .readTextFile("file:///path/to/input.txt")
+                .flatMap(line -> Arrays.asList(line.toLowerCase().split("\\W+")))
+                .withName("Split words")
+                .filter(word -> !word.isEmpty())
+                .withName("Filter empty")
+                .map(word -> new Tuple2<>(word, 1))
+                .withName("Pair with 1")
+                .reduceByKey(
+                        Tuple2::getField0,
+                        (t1, t2) -> new Tuple2<>(t1.getField0(), t1.getField1() + t2.getField1())
+                )
+                .withName("Aggregate counts")
+                .collect();
+
+        // 4. Output results
+        wordCounts.forEach(t -> System.out.println(t.getField0() + ": " + t.getField1()));
+    }
+}
+```
+
+### Execution Lifecycle
+When `.collect()` or a sink action is invoked:
+1. Wayang analyzes the logical plan graph.
+2. The optimizer assigns cost estimates to candidate platform operators.
+3. Wayang selects the cheapest cross-platform execution plan.
+4. Intermediate channels and data conversions are automatically inserted.
+5. The plan is executed across the selected platforms.

--- a/wayang-docs/src/main/resources/how_contribute/code_changes/index.md
+++ b/wayang-docs/src/main/resources/how_contribute/code_changes/index.md
@@ -26,4 +26,4 @@ next:
 
 # Code Changes
 
-Apache Wayang (incubating) is an open source system, and we try to everyone can contribute on it, so feel free to contribute but please read our process to make your life easy 😉. If you have any doubt please write on our [email list@dev](mailto:dev@wayang.apache.org).
+Apache Wayang is an open source system, and we try to everyone can contribute on it, so feel free to contribute but please read our process to make your life easy 😉. If you have any doubt please write on our [email list@dev](mailto:dev@wayang.apache.org).

--- a/wayang-docs/src/main/resources/how_contribute/preparing_releases.md
+++ b/wayang-docs/src/main/resources/how_contribute/preparing_releases.md
@@ -249,14 +249,14 @@ For this we usually send two emails. The following would be the one used to do o
 E-Mail Topic:
 <div style="border: 1px solid gray; padding: 1em;">
 <pre>
-[VOTE] Apache Wayang (incubating) 0.6.0 RC1
+[VOTE] Apache Wayang 1.X.X RC1
 </pre>
 </div>
 
 Message:
 <div style="border: 1px solid gray; padding: 1em;">
 <pre>
-Apache Wayang (incubating) 0.6.0 has been staged under [2] and it’s time to vote on accepting it for release. All Maven artifacts are available under [1].
+Apache Wayang 1.X.X has been staged under [2] and it’s time to vote on accepting it for release. All Maven artifacts are available under [1].
 Voting will be open for 72hr. A minimum of 3 binding +1 votes and more binding +1 than binding -1
 are required to pass.
 
@@ -288,7 +288,7 @@ As it is sometimes to do the vote counting, if voting and discussions are going 
 
 E-Mail Topic:
 <div style="border: 1px solid gray; padding: 1em;">
-<pre>[DISCUSS] Apache Wayang (incubating) 0.6.0 RC1</pre>
+<pre>[DISCUSS] Apache Wayang 1.X.X RC1</pre>
 </div>
 
 
@@ -312,9 +312,9 @@ Now we have to wait 72 hours till we can announce the result of the vote. The vo
 As soon as the votes are finished, and the results were in favor of a release, the staged artifacts can be released. This is done by moving them inside the Apache SVN.
 
 ```shell
-svn move -m "Release Apache Wayang (incubating) 0.6.0" \
-  https://dist.apache.org/repos/dist/dev/wayang/0.6.0/rc1 \
-  https://dist.apache.org/repos/dist/release/wayang/0.6.0
+svn move -m "Release Apache Wayang 1.X.X" \
+  https://dist.apache.org/repos/dist/dev/wayang/1.X.X/rc1 \
+  https://dist.apache.org/repos/dist/release/wayang/1.X.X
 ```
 
 This will make the release artifacts available and will trigger them being copied to mirror sites.

--- a/wayang-docs/src/main/resources/how_contribute/slack_channels.md
+++ b/wayang-docs/src/main/resources/how_contribute/slack_channels.md
@@ -28,5 +28,5 @@ menus:
 
 In case of any doubts, our community will be glad to answer your questions.
 
-Join the Apache Wayang (incubating) slack. After creating account in slack you can join #wayang where you can look for help in using and developing Apache Wayang (incubating).
+Join the Apache Wayang slack. After creating account in slack you can join #wayang where you can look for help in using and developing Apache Wayang.
 

--- a/wayang-docs/src/main/resources/index.md
+++ b/wayang-docs/src/main/resources/index.md
@@ -28,145 +28,77 @@ menus:
         weight: 0
 ---
 
-# Apache Wayang (incubating) <img align="right" style="margin-top: -0.5em;" width="170px" src="https://wayang.apache.org/assets/img/logo/logo_400x160.png" alt="Wayang logo">
+# Apache Wayang <img align="right" style="margin-top: -0.5em;" width="170px" src="https://wayang.apache.org/assets/img/logo/logo_400x160.png" alt="Wayang logo">
 
 [![Build Status (Travis)](https://travis-ci.org/wayang-ecosystem/wayang.svg?branch=master)](https://travis-ci.org/wayang-ecosystem/wayang)
 [![Gitter chat](https://badges.gitter.im/wayang-ecosystem/Lobby.png)](https://gitter.im/wayang-ecosystem/Lobby)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.wayang/wayang/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.wayang/wayang)
 
-#### Apache Wayang (incubating) - A Federated Data Processing Engine
+#### Apache Wayang - A cross-platform data processing system
 
-Unlike conventional data processing systems that depend on a single execution engine, Apache Wayang (incubating) acts as a meta processing framework. It empowers you to specify your data processing application through one of its APIs, and Wayang then intelligently chooses the ideal combination of underlying processing frameworks, like Java Streams or Apache Spark, to run your application efficiently. Wayang seamlessly manages inter-platform communication, eliminating the need to grapple with various platform APIs.
+Unlike conventional data processing systems that depend on a single execution engine, Apache Wayang acts as a meta processing framework. It empowers you to specify your data processing application through one of its APIs, and Wayang then intelligently chooses the ideal combination of underlying processing frameworks, like Java Streams or Apache Spark, to run your application efficiently. Wayang seamlessly manages inter-platform communication, eliminating the need to grapple with various platform APIs.
    
 Wayang has built in support for the following frameworks:
 
-- Apache Flink v1.7.1
-- Apache Giraph v1.2.0-hadoop2
-- GraphChi v0.2.2 (only available with scala 11.x)
-- Java Streams (version depends on the java version)
-- JDBC-Template
-- Postgres v9.4.1208 (Implementation JDBC-Template)
-- Apache Spark v3.1.2 (scala 12.x) and v2.4.8 (scala 11.x)
-- SQLite3 v3.8.11.2 (implementation JDBC-Template)
+- Java Streams (Java 17)
+- Apache Spark v3.5.x
+- Apache Flink v1.20.x
+- PostgreSQL (JDBC)
+- SQLite3 (JDBC)
+- Generic JDBC (Relational databases via JDBC)
+- Trino
+- Presto
+- Google BigQuery
+- TensorFlow (Deep Learning)
+- Apache Giraph v1.2.0
 
 Important note: depending on the scala version the list of the supported platforms available could be different.
 
 ## How to use Wayang
 
-**Requirements.**
-Apache Wayang (incubating) is built upon the foundations of Java 11 and Scala 2.12, providing a robust and versatile platform for data processing applications. If you intend to build Wayang from source, you will also need to have Apache Maven, the popular build automation tool, installed on your system. Additionally, be mindful that some of the processing platforms supported by Wayang may have their own specific installation requirements.
+### Quick Navigation
+- **[How to Build Wayang (Requirements)]({% link getting_start/how_build/index.md %})**: System requirements (Java 17, Scala 2.12, Maven) and source build instructions.
+- **[Wayang Abstractions & Plans]({% link getting_start/writting_wayang_plan/index.md %})**: Learn about Source, Unary, Binary, Loop, and Sink operators and how to build plans using `JavaPlanBuilder`.
+- **[Configuring Wayang]({% link using_wayang/configuring_wayang.md %})**: System properties, platform parameters, and runtime configuration.
+- **[Cost Model Calibration]({% link using_wayang/cost_model_calibration.md %})**: Tuning the cost-based optimizer and calibrating load profile estimators.
+- **[Scalable Deep Learning]({% link using_wayang/scalable_deep_learning.md %})**: Deep learning with `DLModel` and the TensorFlow platform adapter.
+- **[API JavaDocs](https://wayang.apache.org/docs/api/javadocs/)**: Official API reference documentation.
 
-**Get Wayang.**
-Wayang is available via Maven Central. To use it with Maven, for instance, include the following into you POM file:
+---
+
+### Get Wayang
+Wayang is available via Maven Central. To use it with Maven, include the following into your `pom.xml`:
 ```xml
 <dependency>
   <groupId>org.apache.wayang</groupId>
-  <artifactId>wayang-***</artifactId>
-  <version>0.7.1</version>
+  <artifactId>wayang-core</artifactId>
+  <version>${wayang.version}</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.wayang</groupId>
+  <artifactId>wayang-basic</artifactId>
+  <version>${wayang.version}</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.wayang</groupId>
+  <artifactId>wayang-api-scala-java</artifactId>
+  <version>${wayang.version}</version>
 </dependency>
 ```
-Note the `***`: Wayang ships with multiple modules that can be included in your app, depending on how you want to use it:
-* `wayang-core`: provides core data structures and the optimizer (required)
-* `wayang-basic`: provides common operators and data types for your apps (recommended)
-* `wayang-api`: provides an easy-to-use Scala and Java API to assemble Wayang plans (recommended)
-* `wayang-java`, `wayang-spark`, `wayang-graphchi`, `wayang-sqlite3`, `wayang-postgres`: adapters for the various supported processing platforms
-* `wayang-profiler`: provides functionality to learn operator and UDF cost functions from historical execution data
 
-For the sake of version flexibility, you still have to include your Hadoop (`hadoop-hdfs` and `hadoop-common`) and Spark (`spark-core` and `spark-graphx`) version of choice.
+> Replace `${wayang.version}` with the latest stable release (e.g., `1.1.1` from Maven Central) or the latest development snapshot version (e.g., `1.1.2-SNAPSHOT` with Apache Snapshots repository enabled).
 
-In addition, you can obtain the most recent snapshot version of Wayang via Sonatype's snapshot repository. Just included
-```xml
-<repositories>
-  <repository>
-    <id>sonatype-snapshots</id>
-    <name>Sonatype Snapshot Repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-  </repository>
-<repositories>
-```
+Add the platform adapters you wish to target:
+- `wayang-java`: Java Streams platform (single JVM)
+- `wayang-spark`: Apache Spark platform
+- `wayang-flink`: Apache Flink platform
+- `wayang-postgres` / `wayang-sqlite3` / `wayang-generic-jdbc`: Relational database platforms
+- `wayang-trino` / `wayang-presto`: Distributed SQL query engines
+- `wayang-bigquery`: Google BigQuery cloud data warehouse
+- `wayang-tensorflow`: TensorFlow deep learning platform
+- `wayang-giraph`: Graph processing platform
 
-If you need to rebuild Wayang, e.g., to use a different Scala version, you can simply do so via Maven:
-
-1. Adapt the version variables (e.g., `spark.version`) in the main `pom.xml` file.
-2. Build Wayang with the adapted versions.
-   ```shell
-   $ mvn clean install
-   ```
-   Note the `standalone` profile to fix Hadoop and Spark versions, so that Wayang apps do not explicitly need to declare the corresponding dependencies.
-   Also, note the `distro` profile, which assembles a binary Wayang distribution.
-   To activate these profiles, you need to specify them when running maven, i.e.,
-    ```shell
-    mvn clean install -P<profile name>
-    ```
-
-**Configure Wayang.** To enable Apache Wayang's smooth operation, you need to equip it with details about your processing platforms' capabilities and how to interact with them. A default configuration is available for initial testing, but creating a properties file is generally preferable for fine-tuning the configuration to suit your specific requirements. To harness this personalized configuration effortlessly, launch your application via
-```shell
-$ java -Dwayang.configuration=url://to/my/wayang.properties ...
-```
-
-Essential configuration settings:
-* General settings
-    * `wayang.core.log.enabled (= false)`: whether to log execution statistics to allow learning better cardinality and cost estimators for the optimizer
-    * `wayang.core.log.executions (= ~/.wayang/executions.json)` where to log execution times of operator groups
-    * `wayang.core.log.cardinalities (= ~/.wayang/cardinalities.json)` where to log cardinality measurements
-    * `wayang.core.optimizer.instrumentation (= org.apache.wayang.core.profiling.OutboundInstrumentationStrategy)`: where to measure cardinalities in Wayang plans; other options are `org.apache.wayang.core.profiling.NoInstrumentationStrategy` and `org.apache.wayang.core.profiling.FullInstrumentationStrategy`
-    * `wayang.core.optimizer.reoptimize (= false)`: whether to progressively optimize Wayang plans
-    * `wayang.basic.tempdir (= file:///tmp)`: where to store temporary files, in particular for inter-platform communication
-* Java Streams
-    * `wayang.java.cpu.mhz (= 2700)`: clock frequency of processor the JVM runs on in MHz
-    * `wayang.java.hdfs.ms-per-mb (= 2.7)`: average throughput from HDFS to JVM in ms/MB
-* Apache Spark
-    * `spark.master (= local)`: Spark master
-        * various other Spark settings are supported, e.g., `spark.executor.memory`, `spark.serializer`, ...
-    * `wayang.spark.cpu.mhz (= 2700)`: clock frequency of processor the Spark workers run on in MHz
-    * `wayang.spark.hdfs.ms-per-mb (= 2.7)`: average throughput from HDFS to the Spark workers in ms/MB
-    * `wayang.spark.network.ms-per-mb (= 8.6)`: average network throughput of the Spark workers in ms/MB
-    * `wayang.spark.init.ms (= 4500)`: time it takes Spark to initialize in ms
-* GraphChi
-    * `wayang.graphchi.cpu.mhz (= 2700)`: clock frequency of processor GraphChi runs on in MHz
-    * `wayang.graphchi.cpu.cores (= 2)`: number of cores GraphChi runs on
-    * `wayang.graphchi.hdfs.ms-per-mb (= 2.7)`: average throughput from HDFS to GraphChi in ms/MB
-* SQLite
-    * `wayang.sqlite3.jdbc.url`: JDBC URL to use SQLite
-    * `wayang.sqlite3.jdbc.user`: optional user name
-    * `wayang.sqlite3.jdbc.password`: optional password
-    * `wayang.sqlite3.cpu.mhz (= 2700)`: clock frequency of processor SQLite runs on in MHz
-    * `wayang.sqlite3.cpu.cores (= 2)`: number of cores SQLite runs on
-* PostgreSQL
-    * `wayang.postgres.jdbc.url`: JDBC URL to use PostgreSQL
-    * `wayang.postgres.jdbc.user`: optional user name
-    * `wayang.postgres.jdbc.password`: optional password
-    * `wayang.postgres.cpu.mhz (= 2700)`: clock frequency of processor PostgreSQL runs on in MHz
-    * `wayang.postgres.cpu.cores (= 2)`: number of cores PostgreSQL runs on
-
-**Code with Wayang.** To effectively define your applications with Apache Wayang, utilize its Scala or Java API, conveniently found within the `wayang-api` module. For clear illustrations, refer to the provided examples below.
-
-**Learn cost functions.**
-Wayang provides a utility to learn cost functions from historical execution data. Specifically, Wayang can learn configurations for load profile estimators (that estimate CPU load, disk load etc.) for both operators and UDFs, as long as the configuration provides a template for those estimators.
-   
-As an example, the `JavaMapOperator` draws its load profile estimator configuration via the configuration key `wayang.java.map.load`.
-Now, it is possible to specify a load profile estimator template in the configuration under the key `<original key>.template`, e.g.:
-```xml
-wayang.java.map.load.template = {\
-  "in":1, "out":1,\
-  "cpu":"?*in0"\
-}
-```
-This template encapsulates a load profile estimator that requires at minimum one input cardinality and one output cardinality. Furthermore, it simulates CPU load by assuming a direct relationship with the input cardinality. However, more complex functions are possible.
-   
-In particular, you can use
-* the variables `in0`, `in1`, ... and `out0`, `out1`, ... to incorporate the input and output cardinalities, respectively;
-* operator properties, such as `numIterations` for the `PageRankOperator` implementations;
-* the operators `+`, `-`, `*`, `/`, `%`, `^`, and parantheses;
-* the functions `min(x0, x1, ...))`, `max(x0, x1, ...)`, `abs(x)`, `log(x, base)`, `ln(x)`, `ld(x)`;
-* and the constants `e` and `pi`.
-
-While Apache Wayang provides templates for all execution operators, you will need to explicitly define your user-defined functions (UDFs) by specifying their cost functions, which are based on configuration parameters. This involves creating an initial specification and template for each UDF.
-As soon as execution data has been collected, you can initiate:
-```shell
-java ... org.apache.wayang.profiler.ga.GeneticOptimizerApp [configuration URL [execution log]]
-```
-This tool will attempt to determine suitable values for the question marks (`?`) within the load profile estimator templates, aligning them with the collected execution data and pre-defined configuration entries for the load profile estimators. These optimized values can then be directly incorporated into your configuration.
+For advanced build and configuration options, see [How to Build]({% link getting_start/how_build/index.md %}) and [Configuring Wayang]({% link using_wayang/configuring_wayang.md %}).
 
 ## Examples
 

--- a/wayang-docs/src/main/resources/using_wayang/configuring_wayang.md
+++ b/wayang-docs/src/main/resources/using_wayang/configuring_wayang.md
@@ -1,0 +1,116 @@
+---
+license: |
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+layout: default
+title: "Configuring Wayang"
+previous:
+    url: /using_wayang/
+    title: Using Wayang
+next:
+    url: /using_wayang/cost_model_calibration/
+    title: Cost Model Calibration
+menu:
+    using:
+        weight: 5
+---
+
+# Configuring Apache Wayang
+
+To enable Apache Wayang's smooth operation and intelligent optimization, you need to provide details about your processing platforms' capabilities, resources, and connection properties. 
+
+While a default configuration is loaded automatically for local experimentation, creating a custom configuration properties file is recommended for fine-tuning performance or connecting to distributed execution engines.
+
+---
+
+## Loading Custom Configurations
+
+You can load a custom configuration file into your application via the command-line JVM system property:
+
+```shell
+$ java -Dwayang.configuration=file:///path/to/my/wayang.properties -cp ... my.app.Main
+```
+
+Alternatively, you can load or modify configurations programmatically in your Java or Scala application:
+
+```java
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.WayangContext;
+
+Configuration config = new Configuration("file:///path/to/my/wayang.properties");
+config.setProperty("wayang.spark.master", "spark://my-cluster:7077");
+
+WayangContext wayangContext = new WayangContext(config);
+```
+
+---
+
+## Key Configuration Properties
+
+### General Core Settings
+| Property | Default | Description |
+|---|---|---|
+| `wayang.core.log.enabled` | `false` | Whether to log execution statistics to allow learning better cardinality and cost estimators for the optimizer. |
+| `wayang.core.log.executions` | `~/.wayang/executions.json` | Destination path where execution times of operator groups are recorded. |
+| `wayang.core.log.cardinalities` | `~/.wayang/cardinalities.json` | Destination path where cardinality measurements are stored. |
+| `wayang.core.optimizer.instrumentation` | `OutboundInstrumentationStrategy` | Strategy for measuring intermediate cardinalities (`NoInstrumentationStrategy`, `OutboundInstrumentationStrategy`, or `FullInstrumentationStrategy`). |
+| `wayang.core.optimizer.reoptimize` | `false` | Whether to progressively re-optimize execution plans at runtime based on actual intermediate cardinalities. |
+| `wayang.basic.tempdir` | `file:///tmp` | Location used for storing temporary files, especially for inter-platform data exchanges. |
+
+---
+
+### Java Streams Platform
+| Property | Default | Description |
+|---|---|---|
+| `wayang.java.cpu.mhz` | `2700` | Clock frequency (MHz) of the processor executing the local JVM. |
+| `wayang.java.hdfs.ms-per-mb` | `2.7` | Average throughput from HDFS to the local JVM in milliseconds per megabyte. |
+
+---
+
+### Apache Spark Platform
+| Property | Default | Description |
+|---|---|---|
+| `spark.master` | `local` | Spark master URL (e.g., `local[*]`, `spark://host:port`, or `yarn`). |
+| `spark.app.name` | `Wayang App` | Spark application name. |
+| `wayang.spark.cpu.mhz` | `2700` | CPU clock frequency (MHz) of the Spark worker nodes. |
+| `wayang.spark.hdfs.ms-per-mb` | `2.7` | Throughput from HDFS to Spark workers (ms/MB). |
+| `wayang.spark.network.ms-per-mb` | `8.6` | Average network throughput between Spark workers (ms/MB). |
+| `wayang.spark.init.ms` | `4500` | Overhead time (ms) required for Spark context initialization. |
+
+---
+
+### Relational Database Platforms (JDBC)
+
+#### PostgreSQL
+| Property | Description |
+|---|---|
+| `wayang.postgres.jdbc.url` | JDBC connection URL (e.g., `jdbc:postgresql://localhost:5432/mydb`). |
+| `wayang.postgres.jdbc.user` | Database user account name. |
+| `wayang.postgres.jdbc.password` | Database password. |
+| `wayang.postgres.cpu.mhz` | Clock frequency (MHz) of the PostgreSQL database server. |
+| `wayang.postgres.cpu.cores` | Number of CPU cores available on the PostgreSQL database server. |
+
+#### SQLite3
+| Property | Description |
+|---|---|
+| `wayang.sqlite3.jdbc.url` | JDBC connection URL (e.g., `jdbc:sqlite:/path/to/database.db`). |
+| `wayang.sqlite3.cpu.mhz` | Clock frequency (MHz) of the processor running SQLite. |
+| `wayang.sqlite3.cpu.cores` | Available CPU cores on the SQLite host machine. |
+
+---
+
+### Next Steps
+
+For advanced cost-based optimization and calibrating load profile estimator templates with historical workload metrics, see [Cost Model Calibration]({% link using_wayang/cost_model_calibration.md %}).

--- a/wayang-docs/src/main/resources/using_wayang/cost_model_calibration.md
+++ b/wayang-docs/src/main/resources/using_wayang/cost_model_calibration.md
@@ -8,7 +8,7 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,17 +17,74 @@ license: |
 layout: default
 title: "Cost Model Calibration"
 previous:
-    url: /
-    title: previous
+    url: /using_wayang/configuring_wayang/
+    title: Configuring Wayang
 next:
-    url: /
-    title: next
+    url: /using_wayang/scalable_deep_learning/
+    title: Scalable Deep Learning
 menu:
     using:
-        weight: 100
+        weight: 6
 ---
 
-Cost Model Calibration
+# Cost Model Calibration
 
+Apache Wayang incorporates an advanced cost-based optimizer that evaluates possible execution plans and selects the most efficient combination of execution platforms for your workload.
 
+To accurately estimate execution time and resource utilization across heterogeneous platforms, Wayang utilizes **Load Profile Estimators** for both built-in operators and User-Defined Functions (UDFs).
 
+---
+
+## Load Profile Estimator Templates
+
+Wayang allows specifying load profile estimator configurations through mathematical templates. For instance, the Java map operator obtains its load profile configuration via `wayang.java.map.load`.
+
+You can supply a template using the `<key>.template` configuration property:
+
+```properties
+wayang.java.map.load.template = {\
+  "in":1, "out":1,\
+  "cpu":"?*in0"\
+}
+```
+
+### Template Elements
+- **Input and Output Quantities**: `"in": 1, "out": 1` declares the number of inputs and outputs expected by the operator.
+- **Cardinality Variables**: `in0`, `in1`, ... and `out0`, `out1`, ... represent the input and output cardinalities.
+- **Operator Properties**: Access operator properties like `numIterations` for iterative operators (e.g., PageRank).
+- **Operators & Arithmetic**: Use standard operations `+`, `-`, `*`, `/`, `%`, `^`, and parentheses.
+- **Built-in Functions**:
+  - `min(x0, x1, ...)`
+  - `max(x0, x1, ...)`
+  - `abs(x)`
+  - `log(x, base)`, `ln(x)`, `ld(x)`
+- **Mathematical Constants**: `e` and `pi`.
+
+---
+
+## Calibrating with the Genetic Optimizer
+
+When unknown parameters (`?`) are left in your estimator templates, Wayang can learn and calibrate the coefficients from historical execution logs using genetic optimization.
+
+### 1. Enable Execution Logging
+Ensure execution logging is enabled in your `wayang.properties`:
+
+```properties
+wayang.core.log.enabled = true
+wayang.core.log.executions = file:///path/to/executions.json
+wayang.core.log.cardinalities = file:///path/to/cardinalities.json
+```
+
+### 2. Run the Calibration Utility
+Once execution data has been collected from representative application runs, execute the calibration tool:
+
+```shell
+$ java -cp ... org.apache.wayang.profiler.ga.GeneticOptimizerApp \
+    file:///path/to/wayang.properties \
+    file:///path/to/executions.json
+```
+
+The genetic optimizer will evaluate the collected run times against candidate coefficients and output fitted values replacing the question marks (`?`).
+
+### 3. Apply Calibrated Values
+Copy the fitted coefficients directly into your production configuration properties to enable highly accurate cost-based plan selection tailored to your specific hardware cluster.

--- a/wayang-docs/src/main/resources/using_wayang/index.md
+++ b/wayang-docs/src/main/resources/using_wayang/index.md
@@ -8,7 +8,7 @@ license: |
     the License.  You may obtain a copy of the License at
 
          http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,40 @@ license: |
 layout: default
 title: "Using Wayang"
 previous:
-    url: /
-    title: previous
+    url: /getting_start/writting_wayang_plan/
+    title: Wayang Abstractions & Plans
 next:
-    url: /
-    title: next
+    url: /using_wayang/configuring_wayang/
+    title: Configuring Wayang
+menu:
+    header:
+        weight: 3
 ---
 
-Using Wayang
+# Using Apache Wayang
+
+Apache Wayang offers a variety of language APIs, execution adapters, configuration facilities, and optimization utilities to suit different data processing workflows.
+
+---
+
+## User Guides & APIs
+
+### 1. Developer APIs
+- **[API Java & Scala]({% link using_wayang/api_java_scala/index.md %})**: Write type-safe cross-platform data processing pipelines using fluent `PlanBuilder` and lambda transformations.
+- **[API Python (PyWayang)]({% link using_wayang/api_python/index.md %})**: Author pipelines in Python with native Python functions and cross-language execution.
+- **[API SQL]({% link using_wayang/api_sql/index.md %})**: Submit relational SQL queries optimized by Wayang across heterogeneous backends.
+- **[API REST]({% link using_wayang/api_rest/index.md %})**: Submit and monitor Wayang plans via HTTP endpoints.
+- **[API JDBC]({% link using_wayang/api_jdbc/index.md %})**: Connect database clients and BI tools to Wayang.
+
+---
+
+### 2. Configuration & Advanced Capabilities
+- **[Configuring Wayang]({% link using_wayang/configuring_wayang.md %})**: Complete reference of system properties, platform parameters, and tuning flags.
+- **[Cost Model Calibration]({% link using_wayang/cost_model_calibration.md %})**: Calibrating load profile estimator templates with execution logs using the genetic algorithm optimizer.
+- **[Scalable Deep Learning]({% link using_wayang/scalable_deep_learning.md %})**: Deep learning model training and inference pipelines with `DLModel` and the TensorFlow platform adapter.
+
+---
+
+## API JavaDocs Reference
+
+For exhaustive class, method, and package-level documentation, visit the [Wayang API JavaDocs](https://wayang.apache.org/docs/api/javadocs/).

--- a/wayang-docs/src/main/resources/using_wayang/scalable_deep_learning.md
+++ b/wayang-docs/src/main/resources/using_wayang/scalable_deep_learning.md
@@ -1,0 +1,113 @@
+---
+license: |
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+layout: default
+title: "Scalable Deep Learning"
+previous:
+    url: /using_wayang/cost_model_calibration/
+    title: Cost Model Calibration
+next:
+    url: /how_contribute/
+    title: How To Contribute
+menu:
+    using:
+        weight: 7
+---
+
+# Scalable Deep Learning in Apache Wayang
+
+Apache Wayang provides first-class support for scalable deep learning, bridging big data processing platforms with deep learning frameworks.
+
+Through the `wayang-tensorflow` platform module and core deep learning abstractions, Wayang enables distributed data preprocessing (e.g., via Spark or Java Streams) combined seamlessly with GPU/CPU accelerated neural network training and batch inference.
+
+---
+
+## Core Abstractions
+
+### 1. `DLModel`
+`org.apache.wayang.basic.model.DLModel` represents a deep neural network model. It encapsulates the computational graph, layer definitions (e.g., Dense/Linear, Conv2D, Conv3D, BatchNorm, ConvLSTM), and trainable weights.
+
+### 2. `DLTrainingOperator`
+`DLTrainingOperator` trains a deep neural network model on an input dataset. It takes training features and labels as input streams or tensors, executes training epochs with specified loss functions and optimizers, and produces an updated `DLModel`.
+
+### 3. `PredictOperator`
+`PredictOperator` performs high-throughput batch inference. It applies an existing `DLModel` to incoming input data tensors and produces predicted outputs or probability distributions.
+
+---
+
+## The TensorFlow Platform (`wayang-tensorflow`)
+
+Wayang includes a dedicated platform adapter for TensorFlow (`wayang-tensorflow`), utilizing Java bindings and native acceleration to execute deep learning operators on CPUs and GPUs.
+
+### Maven Dependency
+To use TensorFlow capabilities in your Wayang application, add the following dependency:
+
+```xml
+<dependency>
+  <groupId>org.apache.wayang</groupId>
+  <artifactId>wayang-tensorflow</artifactId>
+  <version>${wayang.version}</version>
+</dependency>
+```
+
+> Replace `${wayang.version}` with a released version from Maven Central (e.g., `1.1.1`) or the latest development snapshot version (e.g., `1.1.2-SNAPSHOT` with Apache Snapshots repository configured).
+
+---
+
+## End-to-End Deep Learning Workflow Example
+
+The following example demonstrates setting up an integrated pipeline that loads and preprocesses data before executing inference using `TensorflowPlugin`:
+
+```java
+import org.apache.wayang.api.JavaPlanBuilder;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.WayangContext;
+import org.apache.wayang.java.Java;
+import org.apache.wayang.spark.Spark;
+import org.apache.wayang.tensorflow.Tensorflow;
+import org.apache.wayang.tensorflow.model.TensorflowModel;
+
+public class DeepLearningPipeline {
+
+    public static void main(String[] args) {
+        // 1. Initialize WayangContext with Java, Spark, and TensorFlow plugins
+        WayangContext wayangContext = new WayangContext(new Configuration())
+                .withPlugin(Java.basicPlugin())
+                .withPlugin(Spark.basicPlugin())
+                .withPlugin(Tensorflow.plugin());
+
+        JavaPlanBuilder planBuilder = new JavaPlanBuilder(wayangContext);
+
+        // 2. Load and preprocess input features using distributed Spark / Java
+        // 3. Connect dataflow to TensorFlow execution operators
+        // Wayang automatically handles tensor serialization and platform conversions
+    }
+}
+```
+
+### Supported Neural Network Layers
+`wayang-tensorflow` provides built-in operators for constructing modular architectures:
+- **Fully Connected**: `TensorflowLinear`
+- **Convolutional**: `TensorflowConv2D`, `TensorflowConv3D`
+- **Recurrent & Spatio-Temporal**: `TensorflowConvLSTM2D`
+- **Normalization**: `TensorflowBatchNorm2D`, `TensorflowBatchNorm3D`
+
+---
+
+## Benefits of Wayang's Deep Learning Integration
+
+- **Zero Hand-Coded Glue**: Wayang automatically generates data conversion channels (`TensorChannel`) between data preparation platforms (Java/Spark) and deep learning runtimes.
+- **Hardware Agnostic**: Run inference or training locally during prototyping and scale out across cluster GPUs in production without rewriting data transformation logic.


### PR DESCRIPTION
## Description

- **Reorganized Getting Started**: Moved system requirements into "How to Build", and relocated configuration settings and cost functions to dedicated pages under `using_wayang/`.
- **Added Abstractions & Plan Construction Guide**: Documented the 5 core operator types (Source, Unary, Binary, Loop, Sink) and added an overview of `PlanBuilder`.
- **Added Scalable Deep Learning Guide**: Documented `DLModel`, `DLTrainingOperator`, `PredictOperator`, and TensorFlow platform integration.
- **Enabled Menus & Linked JavaDocs**: Activated site navigation and added direct links to the official API JavaDocs.

Closes #613

---

## Screenshots

### 1. Home Page (Streamlined Navigation)
<img width="958" height="476" alt="image" src="https://github.com/user-attachments/assets/e9b29a0a-4048-49de-9307-5f702c6161ad" />

### 2. How to Build & Requirements
<img width="944" height="408" alt="image" src="https://github.com/user-attachments/assets/c8434ce5-073c-4042-b7b0-812a66d0f207" />

### 3. Core Operator Abstractions & PlanBuilder
<img width="374" height="414" alt="image" src="https://github.com/user-attachments/assets/c3cf54f0-d794-4190-8771-a031ee9600c9" />

### 4. Configuring Wayang & Cost Model Calibration
<img width="950" height="409" alt="image" src="https://github.com/user-attachments/assets/ebec67f3-7cef-42d1-b865-cfeee382e22d" />

### 5. Scalable Deep Learning Guide
<img width="950" height="412" alt="image" src="https://github.com/user-attachments/assets/25ff9ee5-d8a4-4714-a8a0-a33f2006432b" />

