### PR TITLE
[SQL / Core] Preserve tuple schema and validate types between SQL and Java operators

### DIFF
--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/optimizer/channels/DefaultChannelConversion.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/optimizer/channels/DefaultChannelConversion.java
@@ -72,6 +72,18 @@ public class DefaultChannelConversion extends ChannelConversion {
     public DefaultChannelConversion(
             ChannelDescriptor sourceChannelDescriptor,
             ChannelDescriptor targetChannelDescriptor,
+            BiFunction<Channel, Configuration, ExecutionOperator> executionOperatorFactory) {
+        this(
+                sourceChannelDescriptor,
+                targetChannelDescriptor,
+                executionOperatorFactory,
+                "via " + executionOperatorFactory.getClass().getSimpleName()
+        );
+    }
+
+    public DefaultChannelConversion(
+            ChannelDescriptor sourceChannelDescriptor,
+            ChannelDescriptor targetChannelDescriptor,
             BiFunction<Channel, Configuration, ExecutionOperator> executionOperatorFactory,
             String name) {
         super(sourceChannelDescriptor, targetChannelDescriptor);
@@ -89,13 +101,31 @@ public class DefaultChannelConversion extends ChannelConversion {
         assert executionOperator.getNumInputs() <= 1 && executionOperator.getNumOutputs() <= 1;
         executionOperator.setAuxiliary(true);
 
+        if (sourceChannel != null && sourceChannel.getProducerSlot() != null && executionOperator.getNumInputs() > 0) {
+            org.apache.wayang.core.types.DataSetType<?> sourceChannelType = sourceChannel.getProducerSlot().getType();
+            org.apache.wayang.core.types.DataSetType<?> inputType = executionOperator.getInput(0).getType();
+            if (sourceChannelType != null && inputType != null && !inputType.isSupertypeOf(sourceChannelType)) {
+                try {
+                    java.lang.reflect.Method adaptTypeMethod = executionOperator.getClass().getMethod("adaptType", org.apache.wayang.core.types.DataSetType.class);
+                    adaptTypeMethod.invoke(executionOperator, sourceChannelType);
+                } catch (NoSuchMethodException e) {
+                    throw new IllegalArgumentException(String.format(
+                            "Cannot convert channel %s of type %s with %s of type %s: type mismatch.",
+                            sourceChannel, sourceChannelType, executionOperator, inputType));
+                } catch (Exception e) {
+                    throw new IllegalArgumentException(String.format(
+                            "Cannot convert channel %s of type %s with %s of type %s: type mismatch.",
+                            sourceChannel, sourceChannelType, executionOperator, inputType), e);
+                }
+            }
+        }
+
         // Set up the Channels and the ExecutionTask.
         final ExecutionTask task = new ExecutionTask(executionOperator, 1, 1);
         sourceChannel.addConsumer(task, 0);
         final Channel outputChannel = task.initializeOutputChannel(0, configuration);
         sourceChannel.addSibling(outputChannel);
         setCardinalityAndTimeEstimates(sourceChannel, optimizationContexts, optCardinality, task);
-
 
         return outputChannel;
     }

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/plan/executionplan/Channel.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/plan/executionplan/Channel.java
@@ -124,6 +124,25 @@ public abstract class Channel {
             assert this.isReusable() || this.consumers.isEmpty() :
                     String.format("Cannot add %s as consumer of non-reusable %s, there is already %s.",
                             consumer, this, this.consumers);
+            if (this.producerSlot != null && consumer.getOperator() != null && inputIndex < consumer.getOperator().getNumInputs()) {
+                InputSlot<?> consumerInput = consumer.getOperator().getInput(inputIndex);
+                if (consumerInput != null && consumerInput.getType() != null && this.producerSlot.getType() != null) {
+                    if (!consumerInput.getType().isSupertypeOf(this.producerSlot.getType())) {
+                        try {
+                            java.lang.reflect.Method adaptTypeMethod = consumer.getOperator().getClass().getMethod("adaptType", DataSetType.class);
+                            adaptTypeMethod.invoke(consumer.getOperator(), this.producerSlot.getType());
+                        } catch (NoSuchMethodException e) {
+                            throw new IllegalArgumentException(String.format(
+                                    "Cannot add consumer %s (input %d type %s) to channel %s with producer type %s: mismatching types.",
+                                    consumer, inputIndex, consumerInput.getType(), this, this.producerSlot.getType()));
+                        } catch (Exception e) {
+                            throw new IllegalArgumentException(String.format(
+                                    "Cannot add consumer %s (input %d type %s) to channel %s with producer type %s: type mismatch.",
+                                    consumer, inputIndex, consumerInput.getType(), this, this.producerSlot.getType()), e);
+                        }
+                    }
+                }
+            }
             this.consumers.add(consumer);
             consumer.setInputChannel(inputIndex, this);
         }

--- a/wayang-commons/wayang-core/src/test/java/org/apache/wayang/core/optimizer/channels/ChannelTypeValidationTest.java
+++ b/wayang-commons/wayang-core/src/test/java/org/apache/wayang/core/optimizer/channels/ChannelTypeValidationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.core.optimizer.channels;
+
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.plan.executionplan.Channel;
+import org.apache.wayang.core.plan.executionplan.ExecutionTask;
+import org.apache.wayang.core.platform.ChannelDescriptor;
+import org.apache.wayang.core.test.DummyExecutionOperator;
+import org.apache.wayang.core.test.DummyReusableChannel;
+import org.apache.wayang.core.types.DataSetType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChannelTypeValidationTest {
+
+    static class TypedDummyOperator extends DummyExecutionOperator {
+        TypedDummyOperator(DataSetType<?> inputType, DataSetType<?> outputType) {
+            super(inputType != null ? 1 : 0, outputType != null ? 1 : 0, false);
+            if (inputType != null) {
+                this.inputSlots[0] = new org.apache.wayang.core.plan.wayangplan.InputSlot<>("in", this, inputType);
+            }
+            if (outputType != null) {
+                this.outputSlots[0] = new org.apache.wayang.core.plan.wayangplan.OutputSlot<>("out", this, outputType);
+            }
+        }
+    }
+
+    @Test
+    void testChannelAddConsumerThrowsOnIncompatibleTypes() {
+        TypedDummyOperator producerOp = new TypedDummyOperator(null, DataSetType.createDefault(String.class));
+        ExecutionTask producerTask = new ExecutionTask(producerOp);
+        Channel channel = new DummyReusableChannel(DummyReusableChannel.DESCRIPTOR, producerOp.getOutput(0));
+        producerTask.setOutputChannel(0, channel);
+
+        TypedDummyOperator consumerOp = new TypedDummyOperator(DataSetType.createDefault(Integer.class), null);
+        ExecutionTask consumerTask = new ExecutionTask(consumerOp);
+
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> channel.addConsumer(consumerTask, 0)
+        );
+        assertTrue(thrown.getMessage().contains("mismatching types"));
+    }
+
+    @Test
+    void testChannelAddConsumerSucceedsOnCompatibleTypes() {
+        TypedDummyOperator producerOp = new TypedDummyOperator(null, DataSetType.createDefault(String.class));
+        ExecutionTask producerTask = new ExecutionTask(producerOp);
+        Channel channel = new DummyReusableChannel(DummyReusableChannel.DESCRIPTOR, producerOp.getOutput(0));
+        producerTask.setOutputChannel(0, channel);
+
+        TypedDummyOperator consumerOp = new TypedDummyOperator(DataSetType.createDefault(CharSequence.class), null);
+        ExecutionTask consumerTask = new ExecutionTask(consumerOp);
+
+        assertDoesNotThrow(() -> channel.addConsumer(consumerTask, 0));
+    }
+
+    @Test
+    void testDefaultChannelConversionThrowsOnIncompatibleTypes() {
+        TypedDummyOperator producerOp = new TypedDummyOperator(null, DataSetType.createDefault(String.class));
+        Channel channel = new DummyReusableChannel(DummyReusableChannel.DESCRIPTOR, producerOp.getOutput(0));
+
+        DefaultChannelConversion conversion = new DefaultChannelConversion(
+                DummyReusableChannel.DESCRIPTOR,
+                DummyReusableChannel.DESCRIPTOR,
+                (ch, conf) -> new TypedDummyOperator(
+                        DataSetType.createDefault(Integer.class),
+                        DataSetType.createDefault(Integer.class)
+                )
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> conversion.convert(channel, new Configuration(), Collections.emptyList(), null)
+        );
+    }
+}

--- a/wayang-platforms/wayang-bigquery/src/main/java/org/apache/wayang/bigquery/channels/ChannelConversions.java
+++ b/wayang-platforms/wayang-bigquery/src/main/java/org/apache/wayang/bigquery/channels/ChannelConversions.java
@@ -18,9 +18,11 @@
 
 package org.apache.wayang.bigquery.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.bigquery.platform.BigQueryPlatform;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.jdbc.operators.SqlToRddOperator;
 import org.apache.wayang.jdbc.operators.SqlToStreamOperator;
@@ -37,13 +39,23 @@ public class ChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             BigQueryPlatform.getInstance().getSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new SqlToStreamOperator(BigQueryPlatform.getInstance())
+            (channel, conf) -> new SqlToStreamOperator<>(
+                    BigQueryPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final ChannelConversion SQL_TO_UNCACHED_RDD_CONVERSION = new DefaultChannelConversion(
             BigQueryPlatform.getInstance().getSqlQueryChannelDescriptor(),
             RddChannel.UNCACHED_DESCRIPTOR,
-            () -> new SqlToRddOperator(BigQueryPlatform.getInstance())
+            (channel, conf) -> new SqlToRddOperator<>(
+                    BigQueryPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Arrays.asList(

--- a/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/channels/GenericChannelConversions.java
+++ b/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/channels/GenericChannelConversions.java
@@ -18,8 +18,10 @@
 
 package org.apache.wayang.genericjdbc.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.genericjdbc.operators.GenericSqlToStreamOperator;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.genericjdbc.platform.GenericJdbcPlatform;
@@ -35,7 +37,12 @@ public class GenericChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             GenericJdbcPlatform.getInstance().getGenericSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new GenericSqlToStreamOperator(GenericJdbcPlatform.getInstance())
+            (channel, conf) -> new GenericSqlToStreamOperator<>(
+                    GenericJdbcPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Collections.singleton(

--- a/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/operators/GenericSqlToStreamOperator.java
+++ b/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/operators/GenericSqlToStreamOperator.java
@@ -37,10 +37,18 @@ import org.apache.wayang.genericjdbc.platform.GenericJdbcPlatform;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.java.execution.JavaExecutor;
 import org.apache.wayang.java.operators.JavaExecutionOperator;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.operators.JoinOperator;
+import org.apache.wayang.basic.types.RecordType;
+import org.apache.wayang.core.plan.executionplan.Channel;
+import org.apache.wayang.core.plan.executionplan.ExecutionTask;
+import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.jdbc.channels.SqlQueryChannel;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.*;
@@ -50,25 +58,36 @@ import java.util.stream.StreamSupport;
 /**
  * Converts {@link SqlQueryChannel}s into {@link StreamChannel}s.
  */
-public class GenericSqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> implements JavaExecutionOperator, JsonSerializable {
+public class GenericSqlToStreamOperator<Type> extends UnaryToUnaryOperator<Type, Type> implements JavaExecutionOperator, JsonSerializable {
 
     private final GenericJdbcPlatform jdbcPlatform;
 
+    @SuppressWarnings("unchecked")
     public GenericSqlToStreamOperator(GenericJdbcPlatform jdbcPlatform) {
-        this(jdbcPlatform, DataSetType.createDefault(Record.class));
+        this(jdbcPlatform, (DataSetType<Type>) DataSetType.createDefault(Record.class));
     }
 
-    public GenericSqlToStreamOperator(GenericJdbcPlatform jdbcPlatform, DataSetType<Record> dataSetType) {
-        super(dataSetType, dataSetType, false);
+    @SuppressWarnings("unchecked")
+    public GenericSqlToStreamOperator(GenericJdbcPlatform jdbcPlatform, DataSetType<?> dataSetType) {
+        super((DataSetType<Type>) dataSetType, (DataSetType<Type>) dataSetType, false);
         this.jdbcPlatform = jdbcPlatform;
     }
 
-    protected GenericSqlToStreamOperator(GenericSqlToStreamOperator that) {
+    @SuppressWarnings("unchecked")
+    public void adaptType(DataSetType<?> newType) {
+        if (newType != null) {
+            this.inputSlots[0] = new org.apache.wayang.core.plan.wayangplan.InputSlot<>("in", this, (DataSetType<Type>) newType);
+            this.outputSlots[0] = new org.apache.wayang.core.plan.wayangplan.OutputSlot<>("out", this, (DataSetType<Type>) newType);
+        }
+    }
+
+    protected GenericSqlToStreamOperator(GenericSqlToStreamOperator<Type> that) {
         super(that);
         this.jdbcPlatform = that.jdbcPlatform;
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
             ChannelInstance[] inputs,
             ChannelInstance[] outputs,
@@ -90,13 +109,33 @@ public class GenericSqlToStreamOperator extends UnaryToUnaryOperator<Record, Rec
                 .createDatabaseDescriptor(executor.getConfiguration(), jdbcName)
                 .createJdbcConnection();
 
-        Iterator<Record> resultSetIterator = new ResultSetIterator(connection, input.getSqlQuery());
-        Spliterator<Record> resultSetSpliterator =
+        boolean isTuple = false;
+        if (this.getOutputType() != null && Tuple2.class.isAssignableFrom(this.getOutputType().getDataUnitType().getTypeClass())) {
+            isTuple = true;
+        } else if (input.getChannel() != null) {
+            if (input.getChannel().getProducerSlot() != null &&
+                    Tuple2.class.isAssignableFrom(input.getChannel().getProducerSlot().getType().getDataUnitType().getTypeClass())) {
+                isTuple = true;
+            } else if (input.getChannel().getProducer() != null &&
+                    input.getChannel().getProducer().getOperator() instanceof JoinOperator) {
+                isTuple = true;
+            }
+        }
+
+        Iterator<?> resultSetIterator;
+        if (isTuple) {
+            int leftColumnCount = resolveLeftColumnCount(connection, input);
+            resultSetIterator = new Tuple2ResultSetIterator(connection, input.getSqlQuery(), leftColumnCount);
+        } else {
+            resultSetIterator = new ResultSetIterator(connection, input.getSqlQuery());
+        }
+
+        Spliterator<?> resultSetSpliterator =
                 Spliterators.spliteratorUnknownSize(resultSetIterator, 0);
-        Stream<Record> resultSetStream =
+        Stream<?> resultSetStream =
                 StreamSupport.stream(resultSetSpliterator, false);
 
-        output.accept(resultSetStream);
+        output.accept((Stream) resultSetStream);
 
         ExecutionLineageNode queryLineageNode = new ExecutionLineageNode(operatorContext);
         queryLineageNode.add(
@@ -116,6 +155,76 @@ public class GenericSqlToStreamOperator extends UnaryToUnaryOperator<Record, Rec
         output.getLineage().addPredecessor(outputLineageNode);
 
         return queryLineageNode.collectAndMark();
+    }
+
+    public static int resolveLeftColumnCount(Connection connection, SqlQueryChannel.Instance input) {
+        try {
+            if (input.getChannel() != null && input.getChannel().getProducer() != null) {
+                Operator op = input.getChannel().getProducer().getOperator();
+                if (op instanceof JoinOperator) {
+                    JoinOperator<?, ?, ?> joinOp = (JoinOperator<?, ?, ?>) op;
+                    DataSetType<?> in0Type = joinOp.getInput(0).getType();
+                    if (in0Type != null && in0Type.getDataUnitType() instanceof RecordType) {
+                        int count = ((RecordType) in0Type.getDataUnitType()).getFieldNames().length;
+                        if (count > 0) return count;
+                    }
+                    if (joinOp.getKeyDescriptor0() != null && joinOp.getKeyDescriptor0().getSqlImplementation() != null) {
+                        String leftTable = joinOp.getKeyDescriptor0().getSqlImplementation().getField0();
+                        if (leftTable != null && !leftTable.isEmpty()) {
+                            int count = getTableColumnCount(connection, leftTable);
+                            if (count > 0) return count;
+                        }
+                    }
+                }
+                ExecutionTask producerTask = input.getChannel().getProducer();
+                if (producerTask.getNumInputChannels() > 0 && producerTask.getInputChannel(0) != null) {
+                    Channel leftInChannel = producerTask.getInputChannel(0);
+                    if (leftInChannel.getProducerSlot() != null && leftInChannel.getProducerSlot().getType() != null) {
+                        if (leftInChannel.getProducerSlot().getType().getDataUnitType() instanceof RecordType) {
+                            int count = ((RecordType) leftInChannel.getProducerSlot().getType().getDataUnitType()).getFieldNames().length;
+                            if (count > 0) return count;
+                        }
+                    }
+                    if (leftInChannel.getProducer() != null && leftInChannel.getProducer().getOperator() != null) {
+                        Operator leftProducerOp = leftInChannel.getProducer().getOperator();
+                        try {
+                            java.lang.reflect.Method getTableNameMethod = leftProducerOp.getClass().getMethod("getTableName");
+                            String tableName = (String) getTableNameMethod.invoke(leftProducerOp);
+                            if (tableName != null && !tableName.isEmpty()) {
+                                int count = getTableColumnCount(connection, tableName);
+                                if (count > 0) return count;
+                            }
+                        } catch (Exception ignored) {}
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return -1;
+    }
+
+    public static int getTableColumnCount(Connection connection, String tableName) {
+        if (connection == null || tableName == null) return -1;
+        try {
+            DatabaseMetaData metaData = connection.getMetaData();
+            int count = 0;
+            try (ResultSet rs = metaData.getColumns(null, null, tableName, null)) {
+                while (rs.next()) count++;
+            }
+            if (count > 0) return count;
+
+            try (ResultSet rs = metaData.getColumns(null, null, tableName.toUpperCase(), null)) {
+                while (rs.next()) count++;
+            }
+            if (count > 0) return count;
+
+            try (ResultSet rs = metaData.getColumns(null, null, tableName.toLowerCase(), null)) {
+                while (rs.next()) count++;
+            }
+            return count;
+        } catch (SQLException e) {
+            return -1;
+        }
     }
 
     @Override
@@ -194,7 +303,110 @@ public class GenericSqlToStreamOperator extends UnaryToUnaryOperator<Record, Rec
         public void close() {
             if (this.resultSet != null) {
                 try {
+                    Statement st = this.resultSet.getStatement();
                     this.resultSet.close();
+                    if (st != null) {
+                        st.close();
+                    }
+                } catch (Throwable t) {
+                    LogManager.getLogger(this.getClass()).error("Could not close result set.", t);
+                } finally {
+                    this.resultSet = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Exposes a {@link ResultSet} as an {@link Iterator} of {@link Tuple2} containing two {@link Record}s.
+     */
+    public static class Tuple2ResultSetIterator implements Iterator<Tuple2<Record, Record>>, AutoCloseable {
+
+        private ResultSet resultSet;
+        private Tuple2<Record, Record> next;
+        private int leftColumnCount;
+
+        public Tuple2ResultSetIterator(Connection connection, String sqlQuery, int leftColumnCount) {
+            this.leftColumnCount = leftColumnCount;
+            try {
+                Statement st = connection.createStatement();
+                this.resultSet = st.executeQuery(sqlQuery);
+            } catch (SQLException e) {
+                this.close();
+                throw new WayangException("Could not execute SQL.", e);
+            }
+            this.moveToNext();
+        }
+
+        private void moveToNext() {
+            try {
+                if (this.resultSet == null || !this.resultSet.next()) {
+                    this.next = null;
+                    this.close();
+                } else {
+                    ResultSetMetaData metaData = this.resultSet.getMetaData();
+                    final int totalColumnCount = metaData.getColumnCount();
+                    if (this.leftColumnCount <= 0 || this.leftColumnCount >= totalColumnCount) {
+                        int detectedCount = 0;
+                        String firstTable = null;
+                        try {
+                            firstTable = metaData.getTableName(1);
+                        } catch (Exception ignored) {}
+                        if (firstTable != null && !firstTable.isEmpty()) {
+                            for (int i = 1; i <= totalColumnCount; i++) {
+                                if (firstTable.equalsIgnoreCase(metaData.getTableName(i))) {
+                                    detectedCount++;
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                        if (detectedCount > 0 && detectedCount < totalColumnCount) {
+                            this.leftColumnCount = detectedCount;
+                        } else {
+                            this.leftColumnCount = totalColumnCount / 2;
+                        }
+                    }
+
+                    int rightColumnCount = totalColumnCount - this.leftColumnCount;
+                    Object[] leftValues = new Object[this.leftColumnCount];
+                    for (int i = 0; i < this.leftColumnCount; i++) {
+                        leftValues[i] = this.resultSet.getObject(i + 1);
+                    }
+                    Object[] rightValues = new Object[rightColumnCount];
+                    for (int i = 0; i < rightColumnCount; i++) {
+                        rightValues[i] = this.resultSet.getObject(this.leftColumnCount + i + 1);
+                    }
+                    this.next = new Tuple2<>(new Record(leftValues), new Record(rightValues));
+                }
+            } catch (SQLException e) {
+                this.next = null;
+                this.close();
+                throw new WayangException("Exception while iterating the result set.", e);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.next != null;
+        }
+
+        @Override
+        public Tuple2<Record, Record> next() {
+            Tuple2<Record, Record> curNext = this.next;
+            this.moveToNext();
+            return curNext;
+        }
+
+        @Override
+        public void close() {
+            if (this.resultSet != null) {
+                try {
+                    Statement st = this.resultSet.getStatement();
+                    this.resultSet.close();
+                    if (st != null) {
+                        st.close();
+                    }
                 } catch (Throwable t) {
                     LogManager.getLogger(this.getClass()).error("Could not close result set.", t);
                 } finally {
@@ -209,7 +421,7 @@ public class GenericSqlToStreamOperator extends UnaryToUnaryOperator<Record, Rec
         return new WayangJsonObj().put("platform", this.jdbcPlatform.getClass().getCanonicalName());
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings("rawtypes")
     public static GenericSqlToStreamOperator fromJson(WayangJsonObj wayangJsonObj) {
         final String platformClassName = wayangJsonObj.getString("platform");
         GenericJdbcPlatform jdbcPlatform = ReflectionUtils.evaluate(platformClassName + ".getInstance()");

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/SqlToRddOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/SqlToRddOperator.java
@@ -37,29 +37,42 @@ import org.apache.wayang.core.util.json.WayangJsonObj;
 import org.apache.wayang.jdbc.channels.SqlQueryChannel;
 import org.apache.wayang.jdbc.execution.DatabaseDescriptor;
 import org.apache.wayang.jdbc.platform.JdbcPlatformTemplate;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.operators.JoinOperator;
 import org.apache.wayang.spark.channels.RddChannel;
 import org.apache.wayang.spark.execution.SparkExecutor;
 import org.apache.wayang.spark.operators.SparkExecutionOperator;
 
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class SqlToRddOperator extends UnaryToUnaryOperator<Record, Record> implements SparkExecutionOperator, JsonSerializable {
+public class SqlToRddOperator<Type> extends UnaryToUnaryOperator<Type, Type> implements SparkExecutionOperator, JsonSerializable {
 
     private final JdbcPlatformTemplate jdbcPlatform;
 
+    @SuppressWarnings("unchecked")
     public SqlToRddOperator(JdbcPlatformTemplate jdbcPlatform) {
-        this(jdbcPlatform, DataSetType.createDefault(Record.class));
+        this(jdbcPlatform, (DataSetType<Type>) DataSetType.createDefault(Record.class));
     }
 
-    public SqlToRddOperator(JdbcPlatformTemplate jdbcPlatform, DataSetType<Record> dataSetType) {
-        super(dataSetType, dataSetType, false);
+    @SuppressWarnings("unchecked")
+    public SqlToRddOperator(JdbcPlatformTemplate jdbcPlatform, DataSetType<?> dataSetType) {
+        super((DataSetType<Type>) dataSetType, (DataSetType<Type>) dataSetType, false);
         this.jdbcPlatform = jdbcPlatform;
     }
 
-    protected SqlToRddOperator(SqlToRddOperator that) {
+    @SuppressWarnings("unchecked")
+    public void adaptType(DataSetType<?> newType) {
+        if (newType != null) {
+            this.inputSlots[0] = new org.apache.wayang.core.plan.wayangplan.InputSlot<>("in", this, (DataSetType<Type>) newType);
+            this.outputSlots[0] = new org.apache.wayang.core.plan.wayangplan.OutputSlot<>("out", this, (DataSetType<Type>) newType);
+        }
+    }
+
+    protected SqlToRddOperator(SqlToRddOperator<Type> that) {
         super(that);
         this.jdbcPlatform = that.jdbcPlatform;
     }
@@ -133,10 +146,31 @@ public class SqlToRddOperator extends UnaryToUnaryOperator<Record, Record> imple
 
         Dataset<Row> df = reader.load();
 
-        // Convert the distributed DataFrame to JavaRDD<Record> lazily on executors
-        JavaRDD<Record> resultSetRDD = df.toJavaRDD().map(SqlToRddOperator::rowToRecord);
+        boolean isTuple = false;
+        if (this.getOutputType() != null && Tuple2.class.isAssignableFrom(this.getOutputType().getDataUnitType().getTypeClass())) {
+            isTuple = true;
+        } else if (input.getChannel() != null) {
+            if (input.getChannel().getProducerSlot() != null &&
+                    Tuple2.class.isAssignableFrom(input.getChannel().getProducerSlot().getType().getDataUnitType().getTypeClass())) {
+                isTuple = true;
+            } else if (input.getChannel().getProducer() != null &&
+                    input.getChannel().getProducer().getOperator() instanceof JoinOperator) {
+                isTuple = true;
+            }
+        }
 
-        output.accept(resultSetRDD, executor);
+        if (isTuple) {
+            int leftColumnCount = -1;
+            try (Connection conn = databaseDescriptor.createJdbcConnection()) {
+                leftColumnCount = SqlToStreamOperator.resolveLeftColumnCount(conn, input);
+            } catch (Exception ignored) {}
+            final int finalLeftColumnCount = leftColumnCount;
+            JavaRDD<Tuple2<Record, Record>> resultSetRDD = df.toJavaRDD().map(row -> rowToTuple2(row, finalLeftColumnCount));
+            output.accept((JavaRDD) resultSetRDD, executor);
+        } else {
+            JavaRDD<Record> resultSetRDD = df.toJavaRDD().map(SqlToRddOperator::rowToRecord);
+            output.accept((JavaRDD) resultSetRDD, executor);
+        }
 
         ExecutionLineageNode queryLineageNode = new ExecutionLineageNode(operatorContext);
         queryLineageNode.add(LoadProfileEstimators.createFromSpecification(
@@ -161,6 +195,23 @@ public class SqlToRddOperator extends UnaryToUnaryOperator<Record, Record> imple
             fields[i] = row.get(i);
         }
         return new Record(fields);
+    }
+
+    public static Tuple2<Record, Record> rowToTuple2(Row row, int leftColumnCount) {
+        int total = row.size();
+        if (leftColumnCount <= 0 || leftColumnCount >= total) {
+            leftColumnCount = total / 2;
+        }
+        Object[] leftFields = new Object[leftColumnCount];
+        for (int i = 0; i < leftColumnCount; i++) {
+            leftFields[i] = row.get(i);
+        }
+        int rightColumnCount = total - leftColumnCount;
+        Object[] rightFields = new Object[rightColumnCount];
+        for (int i = 0; i < rightColumnCount; i++) {
+            rightFields[i] = row.get(leftColumnCount + i);
+        }
+        return new Tuple2<>(new Record(leftFields), new Record(rightFields));
     }
 
     private static String cleanQuery(String query) {
@@ -196,7 +247,7 @@ public class SqlToRddOperator extends UnaryToUnaryOperator<Record, Record> imple
         return new WayangJsonObj().put("platform", this.jdbcPlatform.getClass().getCanonicalName());
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings("rawtypes")
     public static SqlToRddOperator fromJson(WayangJsonObj wayangJsonObj) {
         final String platformClassName = wayangJsonObj.getString("platform");
         JdbcPlatformTemplate jdbcPlatform = ReflectionUtils.evaluate(platformClassName + ".getInstance()");

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/SqlToStreamOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/SqlToStreamOperator.java
@@ -23,6 +23,8 @@ import org.apache.wayang.basic.types.RecordType;
 import org.apache.wayang.core.api.exception.WayangException;
 import org.apache.wayang.core.optimizer.OptimizationContext;
 import org.apache.wayang.core.optimizer.costs.LoadProfileEstimators;
+import org.apache.wayang.core.plan.executionplan.Channel;
+import org.apache.wayang.core.plan.executionplan.ExecutionTask;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.UnaryToUnaryOperator;
 import org.apache.wayang.core.platform.ChannelDescriptor;
@@ -40,8 +42,13 @@ import org.apache.wayang.jdbc.channels.SqlQueryChannel;
 import org.apache.wayang.jdbc.platform.JdbcPlatformTemplate;
 import org.apache.logging.log4j.LogManager;
 
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.operators.JoinOperator;
+
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
@@ -57,7 +64,7 @@ import java.util.stream.StreamSupport;
 /**
  * This {@link Operator} converts {@link SqlQueryChannel}s to {@link StreamChannel}s.
  */
-public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> implements JavaExecutionOperator, JsonSerializable {
+public class SqlToStreamOperator<Type> extends UnaryToUnaryOperator<Type, Type> implements JavaExecutionOperator, JsonSerializable {
 
     private final JdbcPlatformTemplate jdbcPlatform;
 
@@ -66,27 +73,38 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
      *
      * @param jdbcPlatform from which the SQL data comes
      */
+    @SuppressWarnings("unchecked")
     public SqlToStreamOperator(JdbcPlatformTemplate jdbcPlatform) {
-        this(jdbcPlatform, DataSetType.createDefault(Record.class));
+        this(jdbcPlatform, (DataSetType<Type>) DataSetType.createDefault(Record.class));
     }
 
     /**
      * Creates a new instance.
      *
      * @param jdbcPlatform from which the SQL data comes
-     * @param dataSetType  type of the {@link Record}s being transformed; see {@link RecordType}
+     * @param dataSetType  type of the data passed through the channel (e.g. {@link Record} or {@link Tuple2})
      */
-    public SqlToStreamOperator(JdbcPlatformTemplate jdbcPlatform, DataSetType<Record> dataSetType) {
-        super(dataSetType, dataSetType, false);
+    @SuppressWarnings("unchecked")
+    public SqlToStreamOperator(JdbcPlatformTemplate jdbcPlatform, DataSetType<?> dataSetType) {
+        super((DataSetType<Type>) dataSetType, (DataSetType<Type>) dataSetType, false);
         this.jdbcPlatform = jdbcPlatform;
     }
 
-    protected SqlToStreamOperator(SqlToStreamOperator that) {
+    @SuppressWarnings("unchecked")
+    public void adaptType(DataSetType<?> newType) {
+        if (newType != null) {
+            this.inputSlots[0] = new org.apache.wayang.core.plan.wayangplan.InputSlot<>("in", this, (DataSetType<Type>) newType);
+            this.outputSlots[0] = new org.apache.wayang.core.plan.wayangplan.OutputSlot<>("out", this, (DataSetType<Type>) newType);
+        }
+    }
+
+    protected SqlToStreamOperator(SqlToStreamOperator<Type> that) {
         super(that);
         this.jdbcPlatform = that.jdbcPlatform;
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
             ChannelInstance[] inputs,
             ChannelInstance[] outputs,
@@ -101,11 +119,31 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
                 .createDatabaseDescriptor(executor.getConfiguration())
                 .createJdbcConnection();
 
-        Iterator<Record> resultSetIterator = new ResultSetIterator(connection, input.getSqlQuery());
-        Spliterator<Record> resultSetSpliterator = Spliterators.spliteratorUnknownSize(resultSetIterator, 0);
-        Stream<Record> resultSetStream = StreamSupport.stream(resultSetSpliterator, false);
+        boolean isTuple = false;
+        if (this.getOutputType() != null && Tuple2.class.isAssignableFrom(this.getOutputType().getDataUnitType().getTypeClass())) {
+            isTuple = true;
+        } else if (input.getChannel() != null) {
+            if (input.getChannel().getProducerSlot() != null &&
+                    Tuple2.class.isAssignableFrom(input.getChannel().getProducerSlot().getType().getDataUnitType().getTypeClass())) {
+                isTuple = true;
+            } else if (input.getChannel().getProducer() != null &&
+                    input.getChannel().getProducer().getOperator() instanceof JoinOperator) {
+                isTuple = true;
+            }
+        }
 
-        output.accept(resultSetStream);
+        Iterator<?> resultSetIterator;
+        if (isTuple) {
+            int leftColumnCount = resolveLeftColumnCount(connection, input);
+            resultSetIterator = new Tuple2ResultSetIterator(connection, input.getSqlQuery(), leftColumnCount);
+        } else {
+            resultSetIterator = new ResultSetIterator(connection, input.getSqlQuery());
+        }
+
+        Spliterator<?> resultSetSpliterator = Spliterators.spliteratorUnknownSize(resultSetIterator, 0);
+        Stream<?> resultSetStream = StreamSupport.stream(resultSetSpliterator, false);
+
+        output.accept((Stream) resultSetStream);
 
         ExecutionLineageNode queryLineageNode = new ExecutionLineageNode(operatorContext);
         queryLineageNode.add(LoadProfileEstimators.createFromSpecification(
@@ -121,6 +159,76 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
         output.getLineage().addPredecessor(outputLineageNode);
 
         return queryLineageNode.collectAndMark();
+    }
+
+    public static int resolveLeftColumnCount(Connection connection, SqlQueryChannel.Instance input) {
+        try {
+            if (input.getChannel() != null && input.getChannel().getProducer() != null) {
+                Operator op = input.getChannel().getProducer().getOperator();
+                if (op instanceof JoinOperator) {
+                    JoinOperator<?, ?, ?> joinOp = (JoinOperator<?, ?, ?>) op;
+                    DataSetType<?> in0Type = joinOp.getInput(0).getType();
+                    if (in0Type != null && in0Type.getDataUnitType() instanceof RecordType) {
+                        int count = ((RecordType) in0Type.getDataUnitType()).getFieldNames().length;
+                        if (count > 0) return count;
+                    }
+                    if (joinOp.getKeyDescriptor0() != null && joinOp.getKeyDescriptor0().getSqlImplementation() != null) {
+                        String leftTable = joinOp.getKeyDescriptor0().getSqlImplementation().getField0();
+                        if (leftTable != null && !leftTable.isEmpty()) {
+                            int count = getTableColumnCount(connection, leftTable);
+                            if (count > 0) return count;
+                        }
+                    }
+                }
+                ExecutionTask producerTask = input.getChannel().getProducer();
+                if (producerTask.getNumInputChannels() > 0 && producerTask.getInputChannel(0) != null) {
+                    Channel leftInChannel = producerTask.getInputChannel(0);
+                    if (leftInChannel.getProducerSlot() != null && leftInChannel.getProducerSlot().getType() != null) {
+                        if (leftInChannel.getProducerSlot().getType().getDataUnitType() instanceof RecordType) {
+                            int count = ((RecordType) leftInChannel.getProducerSlot().getType().getDataUnitType()).getFieldNames().length;
+                            if (count > 0) return count;
+                        }
+                    }
+                    if (leftInChannel.getProducer() != null && leftInChannel.getProducer().getOperator() != null) {
+                        Operator leftProducerOp = leftInChannel.getProducer().getOperator();
+                        try {
+                            java.lang.reflect.Method getTableNameMethod = leftProducerOp.getClass().getMethod("getTableName");
+                            String tableName = (String) getTableNameMethod.invoke(leftProducerOp);
+                            if (tableName != null && !tableName.isEmpty()) {
+                                int count = getTableColumnCount(connection, tableName);
+                                if (count > 0) return count;
+                            }
+                        } catch (Exception ignored) {}
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return -1;
+    }
+
+    public static int getTableColumnCount(Connection connection, String tableName) {
+        if (connection == null || tableName == null) return -1;
+        try {
+            DatabaseMetaData metaData = connection.getMetaData();
+            int count = 0;
+            try (ResultSet rs = metaData.getColumns(null, null, tableName, null)) {
+                while (rs.next()) count++;
+            }
+            if (count > 0) return count;
+
+            try (ResultSet rs = metaData.getColumns(null, null, tableName.toUpperCase(), null)) {
+                while (rs.next()) count++;
+            }
+            if (count > 0) return count;
+
+            try (ResultSet rs = metaData.getColumns(null, null, tableName.toLowerCase(), null)) {
+                while (rs.next()) count++;
+            }
+            return count;
+        } catch (SQLException e) {
+            return -1;
+        }
     }
 
     @Override
@@ -214,7 +322,110 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
         public void close() {
             if (this.resultSet != null) {
                 try {
+                    Statement st = this.resultSet.getStatement();
                     this.resultSet.close();
+                    if (st != null) {
+                        st.close();
+                    }
+                } catch (Throwable t) {
+                    LogManager.getLogger(this.getClass()).error("Could not close result set.", t);
+                } finally {
+                    this.resultSet = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Exposes a {@link ResultSet} as an {@link Iterator} of {@link Tuple2} containing two {@link Record}s.
+     */
+    public static class Tuple2ResultSetIterator implements Iterator<Tuple2<Record, Record>>, AutoCloseable {
+
+        private ResultSet resultSet;
+        private Tuple2<Record, Record> next;
+        private int leftColumnCount;
+
+        public Tuple2ResultSetIterator(Connection connection, String sqlQuery, int leftColumnCount) {
+            this.leftColumnCount = leftColumnCount;
+            try {
+                Statement st = connection.createStatement();
+                this.resultSet = st.executeQuery(sqlQuery);
+            } catch (SQLException e) {
+                this.close();
+                throw new WayangException("Could not execute SQL.", e);
+            }
+            this.moveToNext();
+        }
+
+        private void moveToNext() {
+            try {
+                if (this.resultSet == null || !this.resultSet.next()) {
+                    this.next = null;
+                    this.close();
+                } else {
+                    ResultSetMetaData metaData = this.resultSet.getMetaData();
+                    final int totalColumnCount = metaData.getColumnCount();
+                    if (this.leftColumnCount <= 0 || this.leftColumnCount >= totalColumnCount) {
+                        int detectedCount = 0;
+                        String firstTable = null;
+                        try {
+                            firstTable = metaData.getTableName(1);
+                        } catch (Exception ignored) {}
+                        if (firstTable != null && !firstTable.isEmpty()) {
+                            for (int i = 1; i <= totalColumnCount; i++) {
+                                if (firstTable.equalsIgnoreCase(metaData.getTableName(i))) {
+                                    detectedCount++;
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                        if (detectedCount > 0 && detectedCount < totalColumnCount) {
+                            this.leftColumnCount = detectedCount;
+                        } else {
+                            this.leftColumnCount = totalColumnCount / 2;
+                        }
+                    }
+
+                    int rightColumnCount = totalColumnCount - this.leftColumnCount;
+                    Object[] leftValues = new Object[this.leftColumnCount];
+                    for (int i = 0; i < this.leftColumnCount; i++) {
+                        leftValues[i] = this.resultSet.getObject(i + 1);
+                    }
+                    Object[] rightValues = new Object[rightColumnCount];
+                    for (int i = 0; i < rightColumnCount; i++) {
+                        rightValues[i] = this.resultSet.getObject(this.leftColumnCount + i + 1);
+                    }
+                    this.next = new Tuple2<>(new Record(leftValues), new Record(rightValues));
+                }
+            } catch (SQLException e) {
+                this.next = null;
+                this.close();
+                throw new WayangException("Exception while iterating the result set.", e);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.next != null;
+        }
+
+        @Override
+        public Tuple2<Record, Record> next() {
+            Tuple2<Record, Record> curNext = this.next;
+            this.moveToNext();
+            return curNext;
+        }
+
+        @Override
+        public void close() {
+            if (this.resultSet != null) {
+                try {
+                    Statement st = this.resultSet.getStatement();
+                    this.resultSet.close();
+                    if (st != null) {
+                        st.close();
+                    }
                 } catch (Throwable t) {
                     LogManager.getLogger(this.getClass()).error("Could not close result set.", t);
                 } finally {
@@ -229,7 +440,7 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
         return new WayangJsonObj().put("platform", this.jdbcPlatform.getClass().getCanonicalName());
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings("rawtypes")
     public static SqlToStreamOperator fromJson(WayangJsonObj wayangJsonObj) {
         final String platformClassName = wayangJsonObj.getString("platform");
         JdbcPlatformTemplate jdbcPlatform = ReflectionUtils.evaluate(platformClassName + ".getInstance()");

--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/SqlToStreamOperatorTest.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/SqlToStreamOperatorTest.java
@@ -19,9 +19,11 @@
 package org.apache.wayang.jdbc.operators;
 
 import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.data.Tuple2;
 import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.api.Job;
 import org.apache.wayang.core.function.PredicateDescriptor;
+import org.apache.wayang.core.function.TransformationDescriptor;
 import org.apache.wayang.core.optimizer.OptimizationContext;
 import org.apache.wayang.core.plan.executionplan.ExecutionTask;
 import org.apache.wayang.core.plan.wayangplan.ExecutionOperator;
@@ -29,11 +31,13 @@ import org.apache.wayang.core.plan.wayangplan.OutputSlot;
 import org.apache.wayang.core.platform.ChannelInstance;
 import org.apache.wayang.core.platform.CrossPlatformExecutor;
 import org.apache.wayang.core.profiling.FullInstrumentationStrategy;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.java.execution.JavaExecutor;
 import org.apache.wayang.java.platform.JavaPlatform;
 import org.apache.wayang.jdbc.channels.SqlQueryChannel;
 import org.apache.wayang.jdbc.test.HsqldbFilterOperator;
+import org.apache.wayang.jdbc.test.HsqldbJoinOperator;
 import org.apache.wayang.jdbc.test.HsqldbPlatform;
 import org.junit.jupiter.api.Test;
 
@@ -167,6 +171,105 @@ class SqlToStreamOperatorTest extends OperatorTestBase {
 
         List<Record> output = streamChannelInstance.<Record>provideStream().collect(Collectors.toList());
         assertTrue(output.isEmpty());
+    }
+
+    @Test
+    void testJoinWithHsqldbYieldsTuple2() throws SQLException {
+        Configuration configuration = new Configuration();
+
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+
+        CrossPlatformExecutor cpe = new CrossPlatformExecutor(job, new FullInstrumentationStrategy());
+        when(job.getCrossPlatformExecutor()).thenReturn(cpe);
+        final JavaExecutor javaExecutor = new JavaExecutor(JavaPlatform.getInstance(), job);
+
+        HsqldbPlatform hsqldbPlatform = new HsqldbPlatform();
+
+        // Create some test data for join.
+        try (Connection jdbcConnection = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            final Statement statement = jdbcConnection.createStatement();
+            statement.execute("CREATE TABLE usersJoin (id INT, name VARCHAR(20));");
+            statement.execute("INSERT INTO usersJoin VALUES (1, 'Alice');");
+            statement.execute("INSERT INTO usersJoin VALUES (2, 'Bob');");
+
+            statement.execute("CREATE TABLE ordersJoin (order_id INT, user_id INT, amount INT);");
+            statement.execute("INSERT INTO ordersJoin VALUES (101, 1, 50);");
+            statement.execute("INSERT INTO ordersJoin VALUES (102, 2, 75);");
+        }
+
+        final ExecutionOperator joinOperator = new HsqldbJoinOperator<Integer>(
+                new TransformationDescriptor<Record, Integer>(
+                        (record) -> (Integer) record.getField(0),
+                        Record.class,
+                        Integer.class
+                ).withSqlImplementation("usersJoin", "id"),
+                new TransformationDescriptor<Record, Integer>(
+                        (record) -> (Integer) record.getField(1),
+                        Record.class,
+                        Integer.class
+                ).withSqlImplementation("ordersJoin", "user_id")
+        );
+
+        final SqlQueryChannel sqlQueryChannel = new SqlQueryChannel(
+                HsqldbPlatform.getInstance().getSqlQueryChannelDescriptor(),
+                joinOperator.getOutput(0)
+        );
+        ExecutionTask producer = new ExecutionTask(joinOperator);
+        producer.setOutputChannel(0, sqlQueryChannel);
+
+        SqlQueryChannel.Instance sqlQueryChannelInstance = sqlQueryChannel.createInstance(
+                hsqldbPlatform.createExecutor(job),
+                mock(OptimizationContext.OperatorContext.class),
+                0
+        );
+        sqlQueryChannelInstance.setSqlQuery("SELECT * FROM usersJoin JOIN ordersJoin ON usersJoin.id=ordersJoin.user_id;");
+
+        StreamChannel.Instance streamChannelInstance =
+                new StreamChannel(StreamChannel.DESCRIPTOR, mock(OutputSlot.class)).createInstance(
+                        javaExecutor,
+                        mock(OptimizationContext.OperatorContext.class),
+                        0
+                );
+
+        SqlToStreamOperator<Tuple2<Record, Record>> sqlToStreamOperator =
+                new SqlToStreamOperator<>(HsqldbPlatform.getInstance(), joinOperator.getOutput(0).getType());
+
+        evaluate(
+                sqlToStreamOperator,
+                new ChannelInstance[]{sqlQueryChannelInstance},
+                new ChannelInstance[]{streamChannelInstance}
+        );
+
+        List<Tuple2<Record, Record>> output = streamChannelInstance.<Tuple2<Record, Record>>provideStream().collect(Collectors.toList());
+        assertEquals(2, output.size());
+
+        // Verify each element is a Tuple2<Record, Record> and can be consumed safely without ClassCastException
+        Tuple2<Record, Record> firstTuple = output.get(0);
+        assertEquals(new Record(1, "Alice"), firstTuple.getField0());
+        assertEquals(new Record(101, 1, 50), firstTuple.getField1());
+
+        Tuple2<Record, Record> secondTuple = output.get(1);
+        assertEquals(new Record(2, "Bob"), secondTuple.getField0());
+        assertEquals(new Record(102, 2, 75), secondTuple.getField1());
+
+        // Simulate downstream Java map step accessing typed tuple fields
+        List<String> mapped = output.stream()
+                .map(t -> t.getField0().getField(1) + ":" + t.getField1().getField(2))
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList("Alice:50", "Bob:75"), mapped);
+    }
+
+    @Test
+    void testTypeAdaptationAndValidation() {
+        SqlToStreamOperator<?> op = new SqlToStreamOperator<>(HsqldbPlatform.getInstance());
+        assertEquals(Record.class, op.getInput(0).getType().getDataUnitType().getTypeClass());
+        assertEquals(Record.class, op.getOutput(0).getType().getDataUnitType().getTypeClass());
+
+        DataSetType<Tuple2> tupleType = DataSetType.createDefaultUnchecked(Tuple2.class);
+        op.adaptType(tupleType);
+        assertEquals(Tuple2.class, op.getInput(0).getType().getDataUnitType().getTypeClass());
+        assertEquals(Tuple2.class, op.getOutput(0).getType().getDataUnitType().getTypeClass());
     }
 
 }

--- a/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/channels/ChannelConversions.java
+++ b/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/channels/ChannelConversions.java
@@ -18,8 +18,10 @@
 
 package org.apache.wayang.postgres.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.jdbc.operators.SqlToRddOperator;
 import org.apache.wayang.jdbc.operators.SqlToStreamOperator;
@@ -37,13 +39,23 @@ public class ChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             PostgresPlatform.getInstance().getSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new SqlToStreamOperator(PostgresPlatform.getInstance())
+            (channel, conf) -> new SqlToStreamOperator<>(
+                    PostgresPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final ChannelConversion SQL_TO_UNCACHED_RDD_CONVERSION = new DefaultChannelConversion(
             PostgresPlatform.getInstance().getSqlQueryChannelDescriptor(),
             RddChannel.UNCACHED_DESCRIPTOR,
-            () -> new SqlToRddOperator(PostgresPlatform.getInstance())
+            (channel, conf) -> new SqlToRddOperator<>(
+                    PostgresPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Arrays.asList(

--- a/wayang-platforms/wayang-presto/src/main/java/org/apache/wayang/presto/channels/ChannelConversions.java
+++ b/wayang-platforms/wayang-presto/src/main/java/org/apache/wayang/presto/channels/ChannelConversions.java
@@ -18,8 +18,10 @@
 
 package org.apache.wayang.presto.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.jdbc.operators.SqlToRddOperator;
 import org.apache.wayang.jdbc.operators.SqlToStreamOperator;
@@ -38,13 +40,23 @@ public class ChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             PrestoPlatform.getInstance().getSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new SqlToStreamOperator(PrestoPlatform.getInstance())
+            (channel, conf) -> new SqlToStreamOperator<>(
+                    PrestoPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final ChannelConversion SQL_TO_UNCACHED_RDD_CONVERSION = new DefaultChannelConversion(
             PrestoPlatform.getInstance().getSqlQueryChannelDescriptor(),
             RddChannel.UNCACHED_DESCRIPTOR,
-            () -> new SqlToRddOperator(PrestoPlatform.getInstance())
+            (channel, conf) -> new SqlToRddOperator<>(
+                    PrestoPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Arrays.asList(

--- a/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/channels/ChannelConversions.java
+++ b/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/channels/ChannelConversions.java
@@ -18,8 +18,10 @@
 
 package org.apache.wayang.sqlite3.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.jdbc.operators.SqlToRddOperator;
 import org.apache.wayang.jdbc.operators.SqlToStreamOperator;
@@ -38,13 +40,23 @@ public class ChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             Sqlite3Platform.getInstance().getSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new SqlToStreamOperator(Sqlite3Platform.getInstance())
+            (channel, conf) -> new SqlToStreamOperator<>(
+                    Sqlite3Platform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final ChannelConversion SQL_TO_UNCACHED_RDD_CONVERSION = new DefaultChannelConversion(
             Sqlite3Platform.getInstance().getSqlQueryChannelDescriptor(),
             RddChannel.UNCACHED_DESCRIPTOR,
-            () -> new SqlToRddOperator(Sqlite3Platform.getInstance())
+            (channel, conf) -> new SqlToRddOperator<>(
+                    Sqlite3Platform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Arrays.asList(

--- a/wayang-platforms/wayang-trino/src/main/java/org/apache/wayang/trino/channels/ChannelConversions.java
+++ b/wayang-platforms/wayang-trino/src/main/java/org/apache/wayang/trino/channels/ChannelConversions.java
@@ -18,8 +18,10 @@
 
 package org.apache.wayang.trino.channels;
 
+import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.optimizer.channels.ChannelConversion;
 import org.apache.wayang.core.optimizer.channels.DefaultChannelConversion;
+import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.java.channels.StreamChannel;
 import org.apache.wayang.jdbc.operators.SqlToRddOperator;
 import org.apache.wayang.jdbc.operators.SqlToStreamOperator;
@@ -37,13 +39,23 @@ public class ChannelConversions {
     public static final ChannelConversion SQL_TO_STREAM_CONVERSION = new DefaultChannelConversion(
             TrinoPlatform.getInstance().getSqlQueryChannelDescriptor(),
             StreamChannel.DESCRIPTOR,
-            () -> new SqlToStreamOperator(TrinoPlatform.getInstance())
+            (channel, conf) -> new SqlToStreamOperator<>(
+                    TrinoPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final ChannelConversion SQL_TO_UNCACHED_RDD_CONVERSION = new DefaultChannelConversion(
             TrinoPlatform.getInstance().getSqlQueryChannelDescriptor(),
             RddChannel.UNCACHED_DESCRIPTOR,
-            () -> new SqlToRddOperator(TrinoPlatform.getInstance())
+            (channel, conf) -> new SqlToRddOperator<>(
+                    TrinoPlatform.getInstance(),
+                    channel != null && channel.getProducerSlot() != null ?
+                            channel.getProducerSlot().getType() :
+                            DataSetType.createDefault(Record.class)
+            )
     );
 
     public static final Collection<ChannelConversion> ALL = Arrays.asList(


### PR DESCRIPTION
Closes #747

When executing a pipeline involving SQL TableSources, a SQL Join, and downstream Java operators (e.g., `PostgresTableSource -> Join -> SqlToStream -> Java map -> collect`), a runtime `ClassCastException` occurred. 

### Root Cause
1. In Wayang, the output of a SQL `JoinOperator` is structured as `Tuple2<Record, Record>`. However, `SqlToStreamOperator` and `GenericSqlToStreamOperator` hardcoded their output to flat `Record` objects, discarding the tuple structure. When downstream Java operators expected `Tuple2<Record, Record>`, they received raw `Record` objects and threw runtime `ClassCastException`.
2. Neither `Channel.addConsumer` nor `DefaultChannelConversion.convert` performed early schema/type validation between channels and consumers, so mismatches were not caught during plan compilation.

### Changes
- **Generic Operators**: Made `SqlToStreamOperator`, `SqlToRddOperator`, and `GenericSqlToStreamOperator` generic (`<Type>`) with support for emitting `Tuple2<Record, Record>` via `Tuple2ResultSetIterator` and `rowToTuple2`.
- **Dynamic Split Detection**: Implemented `resolveLeftColumnCount` and `getTableColumnCount` using database metadata and operator schemas to accurately partition joined rows into left and right `Record` instances.
- **Dynamic Channel Conversions**: Updated `ChannelConversions` across all SQL platforms (`postgres`, `sqlite3`, `trino`, `presto`, `bigquery`, `generic-jdbc`) to pass the channel producer's data type.
- **Early Type Validation**: Enhanced `Channel.addConsumer` and `DefaultChannelConversion.convert` to validate `consumerInput.getType().isSupertypeOf(producerSlot.getType())` or adapt types via `adaptType(...)`, throwing an early `IllegalArgumentException` on genuine mismatches.
- **Tests**: Added tests for SQL join to Stream `Tuple2` evaluation with Java mapping in `SqlToStreamOperatorTest`, and channel type validation tests in `ChannelTypeValidationTest`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `SqlToStreamOperatorTest` (4 tests passed, including `testJoinWithHsqldbYieldsTuple2` and `testTypeAdaptationAndValidation`).
- `ChannelTypeValidationTest` (3 tests passed, verifying type mismatch rejection and compatible consumer acceptance).
- `JdbcJoinOperatorTest` and `GenericJdbcJoinOperatorTest` passed with 0 failures.
- Clean compilation across all SQL platform modules.